### PR TITLE
[feat] close app if not admin

### DIFF
--- a/CollapseLauncher/XAMLs/Updater/UpdaterWindow.xaml.cs
+++ b/CollapseLauncher/XAMLs/Updater/UpdaterWindow.xaml.cs
@@ -24,6 +24,7 @@ namespace CollapseLauncher
         public static string applyPath = Path.Combine(workingDir, $"ApplyUpdate.exe");
         public static string applyElevatedPath = Path.Combine(workingDir, "_Temp", $"ApplyUpdate.exe");
         public static string elevatedPath = Path.Combine(workingDir, Path.GetFileNameWithoutExtension(sourcePath) + ".Elevated.exe");
+        public static string launcherPath = Path.Combine(workingDir, "CollapseLauncher.exe");
 
         public UpdaterWindow()
         {
@@ -71,13 +72,24 @@ namespace CollapseLauncher
                 {
                     WindowsPrincipal principal = new WindowsPrincipal(identity);
                     if (principal != null && !principal.IsInRole(WindowsBuiltInRole.Administrator)) {
-                        // Ideally implement a self-restart using admin option here, but this works for now. Would also need to add it in the GUI
-                        // if the user does not have console enabled.
-                        LogWriteLine("You are not running as administrator. Please restart the application as an administrator to continue updating.", Hi3Helper.LogType.Warning, false);
-                        LogWriteLine("Press any key to continue...", Hi3Helper.LogType.Warning, false);
+                        // Ideally this would be localized
+                        LogWriteLine("You are not running as Administrator. The application will now attempt to restart as an Administrator to continue updating.", Hi3Helper.LogType.Warning, false);
+                        // NOTE: Lines 79-81 are not required but have been left for debugging purposes, which could be enabled if there is
+                        // a way to check if the user has Console enabled.
+                        // LogWriteLine("Press any key to continue...", Hi3Helper.LogType.Warning, false);
                         // LogWriteLine($"\r{ex}", Hi3Helper.LogType.Error, false);
-                        Console.ReadLine();
+                        // Console.ReadLine();
                         this.Close();
+                        new Process()
+                        {
+                            StartInfo = new ProcessStartInfo
+                            {
+                                UseShellExecute = true,
+                                Verb = "runas",
+                                FileName = launcherPath,
+                                WorkingDirectory = workingDir
+                            }
+                        }.Start();
                     }
                 }
                 // LogWriteLine($"FATAL CRASH!!!\r\n{ex}", Hi3Helper.LogType.Error, true);

--- a/CollapseLauncher/XAMLs/Updater/UpdaterWindow.xaml.cs
+++ b/CollapseLauncher/XAMLs/Updater/UpdaterWindow.xaml.cs
@@ -5,6 +5,7 @@ using Microsoft.UI.Xaml.Media;
 using System;
 using System.Diagnostics;
 using System.IO;
+using System.Security.Principal;
 using Windows.Graphics;
 using WinRT.Interop;
 using static CollapseLauncher.InnerLauncherConfig;
@@ -66,8 +67,21 @@ namespace CollapseLauncher
             }
             catch (Exception ex)
             {
-                LogWriteLine($"FATAL CRASH!!!\r\n{ex}", Hi3Helper.LogType.Error, true);
-                Console.ReadLine();
+                using (WindowsIdentity identity = WindowsIdentity.GetCurrent())
+                {
+                    WindowsPrincipal principal = new WindowsPrincipal(identity);
+                    if (principal != null && !principal.IsInRole(WindowsBuiltInRole.Administrator)) {
+                        // Ideally implement a self-restart using admin option here, but this works for now. Would also need to add it in the GUI
+                        // if the user does not have console enabled.
+                        LogWriteLine("You are not running as administrator. Please restart the application as an administrator to continue updating.", Hi3Helper.LogType.Warning, false);
+                        LogWriteLine("Press any key to continue...", Hi3Helper.LogType.Warning, false);
+                        // LogWriteLine($"\r{ex}", Hi3Helper.LogType.Error, false);
+                        Console.ReadLine();
+                        this.Close();
+                    }
+                }
+                // LogWriteLine($"FATAL CRASH!!!\r\n{ex}", Hi3Helper.LogType.Error, true);
+                // Console.ReadLine();
             }
         }
 


### PR DESCRIPTION
This PR partially addresses #67 by adjusting the following:

- Adds logging to let the user know that the application is not running under admin
- Kills the application after user presses a key in console window

## ToDo:
- Implement some sort of GUI element to allow the user to restart with admin if they do not have Console enabled
OR
- Implement auto-restart if the application detects incorrect permission levels set
- Update README/wiki if the user encounters this error during development, with how to fix it