### PR TITLE
[fix] Removed redundant keywords

### DIFF
--- a/Hi3Helper.Core/Lang/en.json
+++ b/Hi3Helper.Core/Lang/en.json
@@ -573,7 +573,7 @@
     "UpdateStatus4": "You're using the latest version ({0}) now!",
     "UpdateMessage4": "Returning to game launcher scope shortly...",
     "UpdateStatus5": "Version has been updated to {0}!",
-    "UpdateMessage5": "Your launcher will re-open momentarily..."
+    "UpdateMessage5": "Your launcher will re-open shortly..."
   },
 
   "_AppNotification": {
@@ -587,7 +587,7 @@
     "NotifFirstWelcomeBtn": "Visit GitHub Wiki",
 
     "NotifPreviewBuildUsedTitle": "You are using a Preview Build!",
-    "NotifPreviewBuildUsedSubtitle": "You are currently using a PREVIEW build which is still being tested. You may experience some issues if you are using the experimental feature(s) in this build. If you encounter any issues, please report them by using the \"{0}\" button below. Thanks!",
+    "NotifPreviewBuildUsedSubtitle": "You are currently using a PREVIEW build which is still being tested. If you encounter any issues, please report them by using the \"{0}\" button below. Thanks!",
     "NotifPreviewBuildUsedBtn": "Submit an Issue"
   }
 }


### PR DESCRIPTION
This PR directly addresses #62 by changing the keyword to `shortly` from `momentarily` as well as removing a redundant sentence when the user is running a `Preview` release (the build is being tested so we don't need to say that there could be issues in the build as it is inherently assumed from the fact that the build is being tested).

If this PR gets merged, we'll need to close #62 as it is redundant.