### PR TITLE
Some general improvements 

### DIFF
--- a/CollapseLauncher/Classes/GameManagement/GameSettings/Genshin/RegistryClass/GeneralData.cs
+++ b/CollapseLauncher/Classes/GameManagement/GameSettings/Genshin/RegistryClass/GeneralData.cs
@@ -251,6 +251,9 @@ namespace CollapseLauncher.GameSettings.Genshin
 
         /// <summary>
         /// This defines "<c>Gamma</c>" slider in-game. <br/>
+        /// This implementation is quite janky but hear me out <br/>
+        /// The value is directly controlled by Gamma Slider, which linked with GammaValue (NumberBox) <br/>
+        /// Since the value is flipped, math function of y = -x + 4.4 is used (Refer GenshinGameSettingsPage.Ext.cs Line 122)
         /// </summary>
         public double gammaValue { get; set; } = 2.2f;
         

--- a/CollapseLauncher/Classes/GameManagement/GameSettings/Genshin/RegistryClass/GeneralData.cs
+++ b/CollapseLauncher/Classes/GameManagement/GameSettings/Genshin/RegistryClass/GeneralData.cs
@@ -322,7 +322,12 @@ namespace CollapseLauncher.GameSettings.Genshin
                 if (value != null)
                 {
                     ReadOnlySpan<byte> byteStr = (byte[])value;
+#if DEBUG
+                    // If you want to debug GeneralData, Append this to the LogWriteLine:
+                    // '\r\n{Encoding.UTF8.GetString((byte[])value, 0, ((byte[])value).Length - 1)'
+                    // WARNING: VERY EXPENSIVE CPU TIME WILL BE USED
                     LogWriteLine($"Loaded Genshin Settings: {_ValueName}", LogType.Debug, true);
+#endif
                     GeneralData data = (GeneralData?)JsonSerializer.Deserialize(byteStr.Slice(0, byteStr.Length - 1), typeof(GeneralData), GeneralDataContext.Default) ?? new GeneralData();
                     data.graphicsData = GraphicsData.Load(data._graphicsData);
                     data.globalPerfData = new();
@@ -345,11 +350,27 @@ namespace CollapseLauncher.GameSettings.Genshin
 
                 _graphicsData = graphicsData.Save();
                 _globalPerfData = globalPerfData.Create(graphicsData, graphicsData.volatileVersion);
-                LogWriteLine($"Saved Gamma Value {gammaValue}", LogType.Debug);
+ 
                 string data = JsonSerializer.Serialize(this, typeof(GeneralData), GeneralDataContext.Default) + '\0';
                 byte[] dataByte = Encoding.UTF8.GetBytes(data);
-                LogWriteLine($"Saved Genshin Settings: {_ValueName}", LogType.Debug, true);
+
                 RegistryRoot.SetValue(_ValueName, dataByte, RegistryValueKind.Binary);
+#if DEBUG
+                // Only tracking actually used items (besides GlobalPerfData and GraphicsData)
+                LogWriteLine($"Saved Genshin Settings: {_ValueName}" +
+                    $"\r\n      Text Language        : {deviceLanguageType}" +
+                    $"\r\n      VO Language          : {deviceVoiceLanguageType}" +
+                    $"\r\n      Audio - Master Volume: {volumeGlobal}" +
+                    $"\r\n      Audio - Music Volume : {volumeMusic}" +
+                    $"\r\n      Audio - SFX Volume   : {volumeSFX}" +
+                    $"\r\n      Audio - Voice Volume : {volumeVoice}" +
+                    $"\r\n      Audio - Dynamic Range: {audioDynamicRange}" +
+                    $"\r\n      Audio - Surround     : {audioOutput}" +
+                    $"\r\n      Gamma                : {gammaValue}", LogType.Debug);
+                // If you want to debug GeneralData, uncomment this LogWriteLine
+                // WARNING: VERY EXPENSIVE CPU TIME WILL BE USED
+                // LogWriteLine($"Saved Genshin Settings: {_ValueName}\r\n{Encoding.UTF8.GetString((byte[])value, 0, ((byte[])value).Length - 1)", LogType.Debug, true);
+#endif
             }
             catch (Exception ex)
             {
@@ -361,8 +382,8 @@ namespace CollapseLauncher.GameSettings.Genshin
         {
             if (ReferenceEquals(this, comparedTo)) return true;
             if (comparedTo == null) return false;
-            //todo add properties
 
+            // nightmare nightmare nightmare nightmare nightmare 
             return comparedTo.deviceUUID == deviceUUID &&
                 comparedTo.userLocalDataVersionId == userLocalDataVersionId &&
                 comparedTo.deviceLanguageType == deviceLanguageType &&

--- a/CollapseLauncher/Classes/GameManagement/GameSettings/Genshin/RegistryClass/GlobalPerfData.cs
+++ b/CollapseLauncher/Classes/GameManagement/GameSettings/Genshin/RegistryClass/GlobalPerfData.cs
@@ -38,8 +38,6 @@ namespace CollapseLauncher.GameSettings.Genshin
 
         public string Create(GraphicsData graphics, string version)
         {
-            LogWriteLine($"Created Genshin GlobalPerfData\r\n{graphics}", LogType.Debug, true);
-
             saveItems = new()
             {
                 new PerfDataItem (1, (int)graphics.FPS - 1, version),
@@ -60,7 +58,9 @@ namespace CollapseLauncher.GameSettings.Genshin
                 new PerfDataItem (17,(int) graphics.AnisotropicFiltering - 1, version),
             };
             string data = JsonSerializer.Serialize(this, typeof(GlobalPerfData), GlobalPerfDataContext.Default);
-            LogWriteLine($"Created Genshin GlobalPerfData\r\n{data}", LogType.Debug, true);
+#if DEBUG
+            LogWriteLine($"Saved Genshin GlobalPerfData\r\n{data}", LogType.Debug, true);
+#endif
             return data;
         }
         #endregion

--- a/CollapseLauncher/Classes/GameManagement/GameSettings/Genshin/RegistryClass/GraphicsData.cs
+++ b/CollapseLauncher/Classes/GameManagement/GameSettings/Genshin/RegistryClass/GraphicsData.cs
@@ -157,68 +157,117 @@ namespace CollapseLauncher.GameSettings.Genshin
                 switch (setting["key"])
                 {
                     case 1:
+#if DEBUG
                         LogWriteLine($"Loaded Genshin Settings: Graphics - FPS: {setting["value"]}", LogType.Debug, true);
+#endif
                         graphics.FPS = (FPSOption)setting["value"];
                         break;
+
                     case 2:
+#if DEBUG
                         LogWriteLine($"Loaded Genshin Settings: Graphics - Render Resolution: {setting["value"]}", LogType.Debug, true);
+#endif
                         graphics.RenderResolution = (RenderResolutionOption)setting["value"];
                         break;
+
                     case 3:
+#if DEBUG
                         LogWriteLine($"Loaded Genshin Settings: Graphics - Shadow Quality: {setting["value"]}", LogType.Debug, true);
+#endif
                         graphics.ShadowQuality = (ShadowQualityOption)setting["value"];
                         break;
+
                     case 4:
+#if DEBUG
                         LogWriteLine($"Loaded Genshin Settings: Graphics - Visual Effects: {setting["value"]}", LogType.Debug, true);
+#endif
                         graphics.VisualEffects = (VisualEffectsOption)setting["value"];
                         break;
+
                     case 5:
+#if DEBUG
                         LogWriteLine($"Loaded Genshin Settings: Graphics - SFX Quality: {setting["value"]}", LogType.Debug, true);
+#endif
                         graphics.SFXQuality = (SFXQualityOption)setting["value"];
                         break;
+
                     case 6:
+#if DEBUG
                         LogWriteLine($"Loaded Genshin Settings: Graphics - Environment Detail: {setting["value"]}", LogType.Debug, true);
+#endif
                         graphics.EnvironmentDetail = (EnvironmentDetailOption)setting["value"];
                         break;
+
                     case 7:
+#if DEBUG
                         LogWriteLine($"Loaded Genshin Settings: Graphics - Vertical Sync: {setting["value"]}", LogType.Debug, true);
+#endif
                         graphics.VerticalSync = (VerticalSyncOption)setting["value"];
                         break;
+
                     case 8:
+#if DEBUG
                         LogWriteLine($"Loaded Genshin Settings: Graphics - Antialiasing: {setting["value"]}", LogType.Debug, true);
+#endif
                         graphics.Antialiasing = (AntialiasingOption)setting["value"];
                         break;
+
                     case 9:
+#if DEBUG
                         LogWriteLine($"Loaded Genshin Settings: Graphics - Volumetric Fog: {setting["value"]}", LogType.Debug, true);
+#endif
                         graphics.VolumetricFog = (VolumetricFogOption)setting["value"];
                         break;
+
                     case 10:
+#if DEBUG
                         LogWriteLine($"Loaded Genshin Settings: Graphics - Reflections: {setting["value"]}", LogType.Debug, true);
+#endif
                         graphics.Reflections = (ReflectionsOption)setting["value"];
                         break;
+
                     case 11:
+#if DEBUG
                         LogWriteLine($"Loaded Genshin Settings: Graphics - Motion Blur: {setting["value"]}", LogType.Debug, true);
+#endif
                         graphics.MotionBlur = (MotionBlurOption)setting["value"];
                         break;
+
                     case 12:
+#if DEBUG
                         LogWriteLine($"Loaded Genshin Settings: Graphics - Bloom: {setting["value"]}", LogType.Debug, true);
+#endif
                         graphics.Bloom = (BloomOption)setting["value"];
                         break;
+
                     case 13:
+#if DEBUG
                         LogWriteLine($"Loaded Genshin Settings: Graphics - Crowd Density: {setting["value"]}", LogType.Debug, true);
+#endif
                         graphics.CrowdDensity = (CrowdDensityOption)setting["value"];
                         break;
+
+                    // 14 is missing from settings
+                    // And yes, do not reorder this unless the game order finally changes
+                    // It is meant to be like this because miyoyo
                     case 16:
+#if DEBUG
                         LogWriteLine($"Loaded Genshin Settings: Graphics - Co-Op Teammate Effects: {setting["value"]}", LogType.Debug, true);
+#endif
                         graphics.CoOpTeammateEffects = (CoOpTeammateEffectsOption)setting["value"];
                         break;
-                    /// 14 is missing from settings
+
                     case 15:
+#if DEBUG
                         LogWriteLine($"Loaded Genshin Settings: Graphics - Subsurface Scattering: {setting["value"]}", LogType.Debug, true);
+#endif
                         graphics.SubsurfaceScattering = (SubsurfaceScatteringOption)setting["value"];
                         break;
+
                     case 17:
+#if DEBUG
                         LogWriteLine($"Loaded Genshin Settings: Graphics - Anisotropic Filtering: {setting["value"]}", LogType.Debug, true);
+#endif
                         graphics.AnisotropicFiltering = (AnisotropicFilteringOption)setting["value"];
                         break;
                 }
@@ -248,7 +297,9 @@ namespace CollapseLauncher.GameSettings.Genshin
                 new Dictionary<string, int>() { { "key", 17 }, { "value", (int)AnisotropicFiltering } },
                 };
             string data = JsonSerializer.Serialize(this, typeof(GraphicsData), GraphicsDataContext.Default);
+#if DEBUG
             LogWriteLine($"Saved Genshin GraphicsData\r\n{data}", LogType.Debug, true);
+#endif
             return data;
         }
         #endregion

--- a/CollapseLauncher/Classes/GameManagement/GameSettings/Genshin/RegistryClass/ScreenManager.cs
+++ b/CollapseLauncher/Classes/GameManagement/GameSettings/Genshin/RegistryClass/ScreenManager.cs
@@ -114,9 +114,11 @@ namespace CollapseLauncher.GameSettings.Genshin
                     int width = (int)valueWidth;
                     int height = (int)valueHeight;
                     int fullscreen = (int)valueFullscreen;
+#if DEBUG
                     LogWriteLine($"Loaded Genshin Settings: {_ValueNameScreenManagerWidth} : {width}", LogType.Debug, true);
                     LogWriteLine($"Loaded Genshin Settings: {_ValueNameScreenManagerHeight} : {height}", LogType.Debug, true);
                     LogWriteLine($"Loaded Genshin Settings: {_ValueNameScreenManagerFullscreen} : {fullscreen}", LogType.Debug, true);
+#endif
                     return new ScreenManager { width = width, height = height, fullscreen = fullscreen };
                 }
             }
@@ -133,13 +135,19 @@ namespace CollapseLauncher.GameSettings.Genshin
             try
             {
                 RegistryRoot?.SetValue(_ValueNameScreenManagerFullscreen, fullscreen, RegistryValueKind.DWord);
+#if DEBUG
                 LogWriteLine($"Saved Genshin Settings: {_ValueNameScreenManagerFullscreen} : {RegistryRoot.GetValue(_ValueNameScreenManagerFullscreen, null)}", LogType.Debug, true);
+#endif
 
                 RegistryRoot?.SetValue(_ValueNameScreenManagerWidth, width, RegistryValueKind.DWord);
+#if DEBUG
                 LogWriteLine($"Saved Genshin Settings: {_ValueNameScreenManagerWidth} : {RegistryRoot.GetValue(_ValueNameScreenManagerWidth, null)}", LogType.Debug, true);
+#endif
 
                 RegistryRoot?.SetValue(_ValueNameScreenManagerHeight, height, RegistryValueKind.DWord);
+#if DEBUG
                 LogWriteLine($"Saved Genshin Settings: {_ValueNameScreenManagerHeight} : {RegistryRoot.GetValue(_ValueNameScreenManagerHeight, null)}", LogType.Debug, true);
+#endif
             }
             catch (Exception ex)
             {

--- a/CollapseLauncher/Classes/GameManagement/GameSettings/Honkai/RegistryClass/PersonalAudioSetting.cs
+++ b/CollapseLauncher/Classes/GameManagement/GameSettings/Honkai/RegistryClass/PersonalAudioSetting.cs
@@ -184,6 +184,9 @@ namespace CollapseLauncher.GameSettings.Honkai
                 if (value != null)
                 {
                     ReadOnlySpan<byte> byteStr = (byte[])value;
+#if DEBUG
+                    LogWriteLine($"Loaded HI3 Settings: {_ValueName}\r\n{Encoding.UTF8.GetString((byte[])value, 0, ((byte[])value).Length - 1)}", LogType.Debug, true);
+#endif
                     return (PersonalAudioSetting?)JsonSerializer.Deserialize(byteStr.Slice(0, byteStr.Length - 1), typeof(PersonalAudioSetting), PersonalAudioSettingContext.Default) ?? new PersonalAudioSetting();
                 }
             }
@@ -205,6 +208,9 @@ namespace CollapseLauncher.GameSettings.Honkai
                 byte[] dataByte = Encoding.UTF8.GetBytes(data);
 
                 RegistryRoot.SetValue(_ValueName, dataByte, RegistryValueKind.Binary);
+#if DEBUG
+                LogWriteLine($"Saved HI3 Settings: {_ValueName}\r\n{data}", LogType.Debug, true);
+#endif
                 _VolumeValue.Save();
             }
             catch (Exception ex)

--- a/CollapseLauncher/Classes/GameManagement/GameSettings/Honkai/RegistryClass/PersonalGraphicsSettingV2.cs
+++ b/CollapseLauncher/Classes/GameManagement/GameSettings/Honkai/RegistryClass/PersonalGraphicsSettingV2.cs
@@ -158,6 +158,9 @@ namespace CollapseLauncher.GameSettings.Honkai
                 if (value != null)
                 {
                     ReadOnlySpan<byte> byteStr = (byte[])value;
+#if DEBUG
+                    LogWriteLine($"Loaded HI3 Settings: {_ValueName}\r\n{Encoding.UTF8.GetString((byte[])value, 0, ((byte[])value).Length - 1)}", LogType.Debug, true);
+#endif
                     return (PersonalGraphicsSettingV2?)JsonSerializer.Deserialize(byteStr.Slice(0, byteStr.Length - 1), typeof(PersonalGraphicsSettingV2), PersonalGraphicsSettingV2Context.Default) ?? new PersonalGraphicsSettingV2();
                 }
             }
@@ -179,6 +182,9 @@ namespace CollapseLauncher.GameSettings.Honkai
                 byte[] dataByte = Encoding.UTF8.GetBytes(data);
 
                 RegistryRoot.SetValue(_ValueName, dataByte, RegistryValueKind.Binary);
+#if DEBUG
+                LogWriteLine($"Saved HI3 Settings: {_ValueName}\r\n{data}", LogType.Debug, true);
+#endif
             }
             catch (Exception ex)
             {

--- a/CollapseLauncher/Classes/GameManagement/GameSettings/Honkai/RegistryClass/ScreenSettingData.cs
+++ b/CollapseLauncher/Classes/GameManagement/GameSettings/Honkai/RegistryClass/ScreenSettingData.cs
@@ -102,6 +102,9 @@ namespace CollapseLauncher.GameSettings.Honkai
                 if (value != null)
                 {
                     ReadOnlySpan<byte> byteStr = (byte[])value;
+#if DEBUG
+                    LogWriteLine($"Loaded HI3 Settings: {_ValueName}\r\n{Encoding.UTF8.GetString((byte[])value, 0, ((byte[])value).Length - 1)}", LogType.Debug, true);
+#endif
                     return (ScreenSettingData?)JsonSerializer.Deserialize(byteStr.Slice(0, byteStr.Length - 1), typeof(ScreenSettingData), ScreenSettingDataContext.Default) ?? new ScreenSettingData();
                 }
             }
@@ -123,7 +126,9 @@ namespace CollapseLauncher.GameSettings.Honkai
                 byte[] dataByte = Encoding.UTF8.GetBytes(data);
 
                 RegistryRoot.SetValue(_ValueName, dataByte, RegistryValueKind.Binary);
-
+#if DEBUG
+                LogWriteLine($"Saved HI3 Settings: {_ValueName}\r\n{data}", LogType.Debug, true);
+#endif
                 SaveIndividualRegistry();
             }
             catch (Exception ex)

--- a/CollapseLauncher/Classes/GameManagement/GameSettings/StarRail/RegistryClass/BGMVolume.cs
+++ b/CollapseLauncher/Classes/GameManagement/GameSettings/StarRail/RegistryClass/BGMVolume.cs
@@ -37,7 +37,9 @@ namespace CollapseLauncher.GameSettings.StarRail
                 if (value != null)
                 {
                     int bgmVolume = (int)value;
-                    LogWriteLine($"Loaded StarRail Settings: {_ValueName} : {value}", LogType.Default, true);
+#if DEBUG
+                    LogWriteLine($"Loaded StarRail Settings: {_ValueName} : {value}", LogType.Debug, true);
+#endif
                     return new BGMVolume { BGMVol = bgmVolume };
                 }
             }
@@ -54,7 +56,9 @@ namespace CollapseLauncher.GameSettings.StarRail
             {
                 if (RegistryRoot == null) throw new NullReferenceException($"Cannot save {_ValueName} since RegistryKey is unexpectedly not initialized!");
                 RegistryRoot?.SetValue(_ValueName, BGMVol, RegistryValueKind.DWord);
-                LogWriteLine($"Saved StarRail Settings: {_ValueName} : {BGMVol}", LogType.Default, true);
+#if DEBUG
+                LogWriteLine($"Saved StarRail Settings: {_ValueName} : {BGMVol}", LogType.Debug, true);
+#endif
             }
             catch (Exception ex)
             {

--- a/CollapseLauncher/Classes/GameManagement/GameSettings/StarRail/RegistryClass/LocalAudioLanguage.cs
+++ b/CollapseLauncher/Classes/GameManagement/GameSettings/StarRail/RegistryClass/LocalAudioLanguage.cs
@@ -61,7 +61,9 @@ namespace CollapseLauncher.GameSettings.StarRail
                 if (value != null)
                 {
                     string _localAudioLang = Encoding.UTF8.GetString((byte[])value, 0, ((byte[])value).Length - 1);
-                    LogWriteLine($"Loaded StarRail Settings: {_ValueName} : {Encoding.UTF8.GetString((byte[])value, 0, ((byte[])value).Length - 1)}", LogType.Default, true);
+#if DEBUG
+                    LogWriteLine($"Loaded StarRail Settings: {_ValueName} : {Encoding.UTF8.GetString((byte[])value, 0, ((byte[])value).Length - 1)}", LogType.Debug, true);
+#endif
                     return new LocalAudioLanguage { LocalAudioLang = _localAudioLang };
                 }
             }
@@ -80,7 +82,9 @@ namespace CollapseLauncher.GameSettings.StarRail
                 string data = LocalAudioLang + '\0';
                 byte[] dataByte = Encoding.UTF8.GetBytes(data);
                 RegistryRoot?.SetValue(_ValueName, dataByte, RegistryValueKind.Binary);
-                LogWriteLine($"Saved StarRail Settings: {_ValueName} : {data}", LogType.Default, true);
+#if DEBUG
+                LogWriteLine($"Saved StarRail Settings: {_ValueName} : {data}", LogType.Debug, true);
+#endif
             }
             catch (Exception ex)
             {

--- a/CollapseLauncher/Classes/GameManagement/GameSettings/StarRail/RegistryClass/LocalTextLanguage.cs
+++ b/CollapseLauncher/Classes/GameManagement/GameSettings/StarRail/RegistryClass/LocalTextLanguage.cs
@@ -80,7 +80,9 @@ namespace CollapseLauncher.GameSettings.StarRail
                 if (value != null)
                 {
                     string _localTextLang = Encoding.UTF8.GetString((byte[])value, 0, ((byte[])value).Length - 1);
-                    LogWriteLine($"Loaded StarRail Settings: {_ValueName} : {Encoding.UTF8.GetString((byte[])value, 0, ((byte[])value).Length - 1)}", LogType.Default, true);
+#if DEBUG
+                    LogWriteLine($"Loaded StarRail Settings: {_ValueName} : {Encoding.UTF8.GetString((byte[])value, 0, ((byte[])value).Length - 1)}", LogType.Debug, true);
+#endif
                     return new LocalTextLanguage { LocalTextLang = _localTextLang };
                 }
             }
@@ -99,7 +101,9 @@ namespace CollapseLauncher.GameSettings.StarRail
                 string data = LocalTextLang + '\0';
                 byte[] dataByte = Encoding.UTF8.GetBytes(data);
                 RegistryRoot?.SetValue(_ValueName, dataByte, RegistryValueKind.Binary);
-                LogWriteLine($"Saved StarRail Settings: {_ValueName} : {data}", LogType.Default, true);
+#if DEBUG
+                LogWriteLine($"Saved StarRail Settings: {_ValueName} : {data}", LogType.Debug, true);
+#endif
             }
             catch (Exception ex)
             {

--- a/CollapseLauncher/Classes/GameManagement/GameSettings/StarRail/RegistryClass/MasterVolume.cs
+++ b/CollapseLauncher/Classes/GameManagement/GameSettings/StarRail/RegistryClass/MasterVolume.cs
@@ -35,7 +35,9 @@ namespace CollapseLauncher.GameSettings.StarRail
                 if (value != null)
                 {
                     int masterVolume = (int)value;
-                    LogWriteLine($"Loaded StarRail Settings: {_ValueName} : {value}", LogType.Default, true);
+#if DEBUG
+                    LogWriteLine($"Loaded StarRail Settings: {_ValueName} : {value}", LogType.Debug, true);
+#endif
                     return new MasterVolume { MasterVol = masterVolume };
                 }
             }
@@ -52,7 +54,9 @@ namespace CollapseLauncher.GameSettings.StarRail
             {
                 if (RegistryRoot == null) throw new NullReferenceException($"Cannot save {_ValueName} since RegistryKey is unexpectedly not initialized!");
                 RegistryRoot?.SetValue(_ValueName, MasterVol, RegistryValueKind.DWord);
-                LogWriteLine($"Saved StarRail Settings: {_ValueName} : {MasterVol}", LogType.Default, true);
+#if DEBUG
+                LogWriteLine($"Saved StarRail Settings: {_ValueName} : {MasterVol}", LogType.Debug, true);
+#endif
             }
             catch (Exception ex)
             {

--- a/CollapseLauncher/Classes/GameManagement/GameSettings/StarRail/RegistryClass/Model.cs
+++ b/CollapseLauncher/Classes/GameManagement/GameSettings/StarRail/RegistryClass/Model.cs
@@ -12,6 +12,8 @@ using static Hi3Helper.Logger;
 
 namespace CollapseLauncher.GameSettings.StarRail
 {
+
+    #region Enums
     public enum Quality // TypeDefIndex: 11339
     {
         None = 0,
@@ -28,6 +30,7 @@ namespace CollapseLauncher.GameSettings.StarRail
         TAA = 1,
         FXAA = 2
     }
+#endregion
 
     internal class Model : IGameSettingsValue<Model>
     {
@@ -139,7 +142,9 @@ namespace CollapseLauncher.GameSettings.StarRail
                 if (value != null)
                 {
                     ReadOnlySpan<byte> byteStr = (byte[])value;
-                    LogWriteLine($"Loaded StarRail Settings: {_ValueName}\r\n{Encoding.UTF8.GetString((byte[])value, 0, ((byte[])value).Length - 1)}", LogType.Default, true);
+#if DEBUG
+                    LogWriteLine($"Loaded StarRail Settings: {_ValueName}\r\n{Encoding.UTF8.GetString((byte[])value, 0, ((byte[])value).Length - 1)}", LogType.Debug, true);
+#endif
                     return (Model?)JsonSerializer.Deserialize(byteStr.Slice(0, byteStr.Length - 1), typeof(Model), ModelContext.Default) ?? new Model();
                 }
             }
@@ -160,7 +165,9 @@ namespace CollapseLauncher.GameSettings.StarRail
                 string data = JsonSerializer.Serialize(this, typeof(Model), ModelContext.Default) + '\0';
                 byte[] dataByte = Encoding.UTF8.GetBytes(data);
                 RegistryRoot.SetValue(_ValueName, dataByte, RegistryValueKind.Binary);
-                LogWriteLine($"Saved StarRail Settings: {_ValueName}\r\n{data}", LogType.Default, true);
+#if DEBUG
+                LogWriteLine($"Saved StarRail Settings: {_ValueName}\r\n{data}", LogType.Debug, true);
+#endif
             }
             catch (Exception ex)
             {

--- a/CollapseLauncher/Classes/GameManagement/GameSettings/StarRail/RegistryClass/PCResolution.cs
+++ b/CollapseLauncher/Classes/GameManagement/GameSettings/StarRail/RegistryClass/PCResolution.cs
@@ -89,8 +89,9 @@ namespace CollapseLauncher.GameSettings.StarRail
         /// </summary>
         public override bool isfullScreen { get; set; } = true;
         #endregion
-#nullable enable
+
         #region Methods
+#nullable enable
         public static PCResolution Load()
         {
             try
@@ -102,7 +103,9 @@ namespace CollapseLauncher.GameSettings.StarRail
                 if (value != null)
                 {
                     ReadOnlySpan<byte> byteStr = (byte[])value;
-                    LogWriteLine($"Loaded StarRail Settings: {_ValueName}\r\n{Encoding.UTF8.GetString((byte[])value, 0, ((byte[])value).Length - 1)}", LogType.Default, true);
+#if DEBUG
+                    LogWriteLine($"Loaded StarRail Settings: {_ValueName}\r\n{Encoding.UTF8.GetString((byte[])value, 0, ((byte[])value).Length - 1)}", LogType.Debug, true);
+#endif
                     return (PCResolution?)JsonSerializer.Deserialize(byteStr.Slice(0, byteStr.Length - 1), typeof(PCResolution), PCResolutionContext.Default) ?? new PCResolution();
                 }
             }
@@ -124,7 +127,9 @@ namespace CollapseLauncher.GameSettings.StarRail
                 byte[] dataByte = Encoding.UTF8.GetBytes(data);
 
                 RegistryRoot.SetValue(_ValueName, dataByte, RegistryValueKind.Binary);
-                LogWriteLine($"Saved StarRail Settings: {_ValueName}\r\n{data}", LogType.Default, true);
+#if DEBUG
+                LogWriteLine($"Saved StarRail Settings: {_ValueName}\r\n{data}", LogType.Debug, true);
+#endif
                 SaveIndividualRegistry();
             }
             catch (Exception ex)
@@ -136,11 +141,13 @@ namespace CollapseLauncher.GameSettings.StarRail
         private void SaveIndividualRegistry()
         {
             RegistryRoot?.SetValue(_ValueNameScreenManagerFullscreen, isfullScreen ? 1 : 3, RegistryValueKind.DWord);
-            LogWriteLine($"Saved StarRail Settings: {_ValueNameScreenManagerFullscreen} : {RegistryRoot.GetValue(_ValueNameScreenManagerFullscreen, null)}", LogType.Default, true);
             RegistryRoot?.SetValue(_ValueNameScreenManagerWidth, width, RegistryValueKind.DWord);
-            LogWriteLine($"Saved StarRail Settings: {_ValueNameScreenManagerWidth} : {RegistryRoot.GetValue(_ValueNameScreenManagerWidth, null)}", LogType.Default, true);
             RegistryRoot?.SetValue(_ValueNameScreenManagerHeight, height, RegistryValueKind.DWord);
-            LogWriteLine($"Saved StarRail Settings: {_ValueNameScreenManagerHeight} : {RegistryRoot.GetValue(_ValueNameScreenManagerHeight, null)}", LogType.Default, true);
+#if DEBUG
+            LogWriteLine($"Saved StarRail Settings: {_ValueNameScreenManagerFullscreen} : {RegistryRoot.GetValue(_ValueNameScreenManagerFullscreen, null)}", LogType.Debug, true);
+            LogWriteLine($"Saved StarRail Settings: {_ValueNameScreenManagerWidth} : {RegistryRoot.GetValue(_ValueNameScreenManagerWidth, null)}", LogType.Debug, true);
+            LogWriteLine($"Saved StarRail Settings: {_ValueNameScreenManagerHeight} : {RegistryRoot.GetValue(_ValueNameScreenManagerHeight, null)}", LogType.Debug, true);
+#endif
         }
 
         public bool Equals(PCResolution? comparedTo)
@@ -153,8 +160,7 @@ namespace CollapseLauncher.GameSettings.StarRail
                 comparedTo.width == this.width &&
                 comparedTo.isfullScreen == this.isfullScreen;
         }
-        #endregion
 #nullable disable
-
+        #endregion
     }
 }

--- a/CollapseLauncher/Classes/GameManagement/GameSettings/StarRail/RegistryClass/SFXVolume.cs
+++ b/CollapseLauncher/Classes/GameManagement/GameSettings/StarRail/RegistryClass/SFXVolume.cs
@@ -35,7 +35,9 @@ namespace CollapseLauncher.GameSettings.StarRail
                 if (value != null)
                 {
                     int sfxVolume = (int)value;
-                    LogWriteLine($"Loaded StarRail Settings: {_ValueName} : {value}", LogType.Default, true);
+#if DEBUG
+                    LogWriteLine($"Loaded StarRail Settings: {_ValueName} : {value}", LogType.Debug, true);
+#endif
                     return new SFXVolume { SFXVol = sfxVolume };
                 }
             }
@@ -52,7 +54,9 @@ namespace CollapseLauncher.GameSettings.StarRail
             {
                 if (RegistryRoot == null) throw new NullReferenceException($"Cannot save {_ValueName} since RegistryKey is unexpectedly not initialized!");
                 RegistryRoot?.SetValue(_ValueName, SFXVol, RegistryValueKind.DWord);
-                LogWriteLine($"Saved StarRail Settings: {_ValueName} : {SFXVol}", LogType.Default, true);
+#if DEBUG
+                LogWriteLine($"Saved StarRail Settings: {_ValueName} : {SFXVol}", LogType.Debug, true);
+#endif
             }
             catch (Exception ex)
             {

--- a/CollapseLauncher/Classes/GameManagement/GameSettings/StarRail/RegistryClass/VOVolume.cs
+++ b/CollapseLauncher/Classes/GameManagement/GameSettings/StarRail/RegistryClass/VOVolume.cs
@@ -35,7 +35,9 @@ namespace CollapseLauncher.GameSettings.StarRail
                 if (value != null)
                 {
                     int voVolume = (int)value;
-                    LogWriteLine($"Loaded StarRail Settings: {_ValueName} : {value}", LogType.Default, true);
+#if DEBUG
+                    LogWriteLine($"Loaded StarRail Settings: {_ValueName} : {value}", LogType.Debug, true);
+#endif
                     return new VOVolume { VOVol = voVolume };
                 }
             }
@@ -52,7 +54,9 @@ namespace CollapseLauncher.GameSettings.StarRail
             {
                 if (RegistryRoot == null) throw new NullReferenceException($"Cannot save {_ValueName} since RegistryKey is unexpectedly not initialized!");
                 RegistryRoot?.SetValue(_ValueName, VOVol, RegistryValueKind.DWord);
-                LogWriteLine($"Saved StarRail Settings: {_ValueName} : {VOVol}", LogType.Default, true);
+#if DEBUG
+                LogWriteLine($"Saved StarRail Settings: {_ValueName} : {VOVol}", LogType.Debug, true);
+#endif
             }
             catch (Exception ex)
             {

--- a/CollapseLauncher/Classes/GameManagement/GameSettings/Universal/RegistryClass/CollapseScreenSetting.cs
+++ b/CollapseLauncher/Classes/GameManagement/GameSettings/Universal/RegistryClass/CollapseScreenSetting.cs
@@ -55,7 +55,7 @@ namespace CollapseLauncher.GameSettings.Universal
                 {
                     ReadOnlySpan<byte> byteStr = (byte[])value;
 #if DEBUG
-                    LogWriteLine($"Loaded Collapse Screen Settings:\r\n{JsonSerializer.Deserialize(byteStr.Slice(0, byteStr.Length - 1), typeof(CollapseScreenSetting), CollapseScreenSettingContext.Default)}", LogType.Debug, true);
+                    LogWriteLine($"Loaded Collapse Screen Settings:\r\n{Encoding.UTF8.GetString((byte[])value, 0, ((byte[])value).Length - 1)}", LogType.Debug, true);
 #endif
                     return (CollapseScreenSetting?)JsonSerializer.Deserialize(byteStr.Slice(0, byteStr.Length - 1), typeof(CollapseScreenSetting), CollapseScreenSettingContext.Default) ?? new CollapseScreenSetting();
                 }

--- a/CollapseLauncher/Classes/GameManagement/GameSettings/Universal/RegistryClass/CollapseScreenSetting.cs
+++ b/CollapseLauncher/Classes/GameManagement/GameSettings/Universal/RegistryClass/CollapseScreenSetting.cs
@@ -54,6 +54,9 @@ namespace CollapseLauncher.GameSettings.Universal
                 if (value != null)
                 {
                     ReadOnlySpan<byte> byteStr = (byte[])value;
+#if DEBUG
+                    LogWriteLine($"Loaded Collapse Screen Settings:\r\n{byteStr}", LogType.Debug, true);
+#endif
                     return (CollapseScreenSetting?)JsonSerializer.Deserialize(byteStr.Slice(0, byteStr.Length - 1), typeof(CollapseScreenSetting), CollapseScreenSettingContext.Default) ?? new CollapseScreenSetting();
                 }
             }
@@ -73,7 +76,9 @@ namespace CollapseLauncher.GameSettings.Universal
 
                 string data = JsonSerializer.Serialize(this, typeof(CollapseScreenSetting), CollapseScreenSettingContext.Default) + '\0';
                 byte[] dataByte = Encoding.UTF8.GetBytes(data);
-
+#if DEBUG
+                LogWriteLine($"Saved Collapse Screen Settings:\r\n{data}", LogType.Debug, true);
+#endif
                 RegistryRoot.SetValue(_ValueName, dataByte, RegistryValueKind.Binary);
             }
             catch (Exception ex)

--- a/CollapseLauncher/Classes/GameManagement/GameSettings/Universal/RegistryClass/CollapseScreenSetting.cs
+++ b/CollapseLauncher/Classes/GameManagement/GameSettings/Universal/RegistryClass/CollapseScreenSetting.cs
@@ -55,7 +55,7 @@ namespace CollapseLauncher.GameSettings.Universal
                 {
                     ReadOnlySpan<byte> byteStr = (byte[])value;
 #if DEBUG
-                    LogWriteLine($"Loaded Collapse Screen Settings:\r\n{byteStr}", LogType.Debug, true);
+                    LogWriteLine($"Loaded Collapse Screen Settings:\r\n{JsonSerializer.Deserialize(byteStr.Slice(0, byteStr.Length - 1), typeof(CollapseScreenSetting), CollapseScreenSettingContext.Default)}", LogType.Debug, true);
 #endif
                     return (CollapseScreenSetting?)JsonSerializer.Deserialize(byteStr.Slice(0, byteStr.Length - 1), typeof(CollapseScreenSetting), CollapseScreenSettingContext.Default) ?? new CollapseScreenSetting();
                 }

--- a/CollapseLauncher/Classes/GameManagement/GameSettings/Universal/RegistryClass/CustomArgs.cs
+++ b/CollapseLauncher/Classes/GameManagement/GameSettings/Universal/RegistryClass/CustomArgs.cs
@@ -36,7 +36,9 @@ namespace CollapseLauncher.GameSettings.Universal
             try
             {
                 if (RegistryRoot == null) throw new NullReferenceException($"Cannot load {_ValueName} RegistryKey is unexpectedly not initialized!");
-
+#if DEBUG
+                LogWriteLine($"Loaded Collapse Custom Argument Settings:\r\n{(string?)RegistryRoot.GetValue(_ValueName, null) ?? ""}", LogType.Debug, true);
+#endif
                 return new CustomArgs { CustomArgumentValue = (string?)RegistryRoot.GetValue(_ValueName, null) ?? "" };
             }
             catch (Exception ex)
@@ -51,7 +53,9 @@ namespace CollapseLauncher.GameSettings.Universal
             try
             {
                 if (RegistryRoot == null) throw new NullReferenceException($"Cannot save {_ValueName} since RegistryKey is unexpectedly not initialized!");
-
+#if DEBUG
+                LogWriteLine($"Saved Collapse Custom Argument Settings:\r\n{CustomArgumentValue}", LogType.Debug, true);
+#endif
                 RegistryRoot.SetValue(_ValueName, CustomArgumentValue, RegistryValueKind.String);
             }
             catch (Exception ex)

--- a/CollapseLauncher/XAMLs/MainApp/Pages/Dialogs/SimpleDialogs.cs
+++ b/CollapseLauncher/XAMLs/MainApp/Pages/Dialogs/SimpleDialogs.cs
@@ -74,7 +74,7 @@ namespace CollapseLauncher.Dialogs
                     Content,
                     null,
                     Lang._Misc.LocateExecutable,
-                    Lang._Misc.Cancel
+                    Lang._Misc.OpenDownloadPage
                 );
 
         public static async Task<ContentDialogResult> Dialog_InsufficientWritePermission(UIElement Content, string path) =>

--- a/CollapseLauncher/XAMLs/MainApp/Pages/GameSettingsPage.xaml
+++ b/CollapseLauncher/XAMLs/MainApp/Pages/GameSettingsPage.xaml
@@ -59,7 +59,7 @@
                                                HorizontalAlignment="Left" Width="100"/>
                                 </StackPanel>
                             </StackPanel>
-                            <TextBlock Text="{x:Bind helper:Locale.Lang._GameSettingsPage.Graphics_FPSPanel}" Style="{ThemeResource SubtitleTextBlockStyle}" Margin="0,16"/>
+                            <TextBlock Text="{x:Bind helper:Locale.Lang._GameSettingsPage.Graphics_FPSPanel}" Style="{ThemeResource SubtitleTextBlockStyle}" Margin="0,8"/>
                             <StackPanel x:Name="GameMaxFPSPanel" Margin="0,8" Orientation="Horizontal">
                                 <StackPanel x:Name="GameMaxFPSInCombatPanel" Orientation="Vertical">
                                     <TextBlock Text="{x:Bind helper:Locale.Lang._GameSettingsPage.Graphics_FPSInCombat}" VerticalAlignment="Center" Margin="0,0,0,8"/>
@@ -80,7 +80,7 @@
                                     </StackPanel>
                                 </StackPanel>
                             </StackPanel>
-                            <TextBlock Text="{x:Bind helper:Locale.Lang._GameSettingsPage.Graphics_APIPanel}" Style="{ThemeResource SubtitleTextBlockStyle}" Margin="0,24"/>
+                            <TextBlock Text="{x:Bind helper:Locale.Lang._GameSettingsPage.Graphics_APIPanel}" Style="{ThemeResource SubtitleTextBlockStyle}" Margin="0,16"/>
                             <StackPanel x:Name="GraphicsAPIPanel" Orientation="Horizontal">
                                 <ComboBox x:Name="GraphicsAPISelector" SelectedIndex="{x:Bind GraphicsAPI, Mode=TwoWay}" PlaceholderText="Select" Width="224" CornerRadius="14">
                                     <ComboBoxItem Content="DirectX 11 (FL 10.1)"/>
@@ -119,7 +119,7 @@
                             <TextBlock Text="{x:Bind helper:Locale.Lang._GameSettingsPage.Graphics_SpecPanel}" Style="{ThemeResource SubtitleTextBlockStyle}" Margin="0,0,0,16"/>
                             <StackPanel>
                                 <TextBlock Text="{x:Bind helper:Locale.Lang._GameSettingsPage.Graphics_Preset}" Style="{ThemeResource BodyStrongTextBlockStyle}" Margin="0,0,0,8"/>
-                                <ComboBox x:Name="GameGraphicsPresetSelector" Margin="0,8,0,16" CornerRadius="14"
+                                <ComboBox x:Name="GameGraphicsPresetSelector" Margin="0,0,0,16" CornerRadius="14"
                                           ItemsSource="{x:Bind PresetRenderingNames}" SelectedIndex="{x:Bind PresetRenderingIndex, Mode=TwoWay}"/>
                                 <Grid>
                                     <Grid.ColumnDefinitions>
@@ -129,7 +129,7 @@
                                     </Grid.ColumnDefinitions>
                                     <StackPanel Grid.Column="0">
                                         <TextBlock Text="{x:Bind helper:Locale.Lang._GameSettingsPage.Graphics_Render}" Style="{ThemeResource BodyStrongTextBlockStyle}" Margin="0,0,0,8"/>
-                                        <ComboBox x:Name="RenderingAccuracySelector" Margin="0,8,0,8" Width="128"
+                                        <ComboBox x:Name="RenderingAccuracySelector" Margin="0,0,0,8" Width="128"
                                                   SelectedIndex="{x:Bind GraphicsRenderingAccuracy, Mode=TwoWay}" CornerRadius="14">
                                             <ComboBoxItem Content="{x:Bind helper:Locale.Lang._GameSettingsPage.SpecLow}"/>
                                             <ComboBoxItem Content="{x:Bind helper:Locale.Lang._GameSettingsPage.SpecMedium}"/>
@@ -139,7 +139,7 @@
                                     </StackPanel>
                                     <StackPanel Grid.Column="1">
                                         <TextBlock Text="{x:Bind helper:Locale.Lang._GameSettingsPage.Graphics_Shadow}" Style="{ThemeResource BodyStrongTextBlockStyle}" Margin="0,0,0,8"/>
-                                        <ComboBox x:Name="ShadowQualitySelector" Margin="0,8,0,8" Width="128"
+                                        <ComboBox x:Name="ShadowQualitySelector" Margin="0,0,0,8" Width="128"
                                                   SelectedIndex="{x:Bind GraphicsShadowQuality, Mode=TwoWay}" CornerRadius="14">
                                             <ComboBoxItem Content="{x:Bind helper:Locale.Lang._GameSettingsPage.SpecDisabled}"/>
                                             <ComboBoxItem Content="{x:Bind helper:Locale.Lang._GameSettingsPage.SpecLow}"/>
@@ -150,7 +150,7 @@
                                     </StackPanel>
                                     <StackPanel Grid.Column="2">
                                         <TextBlock Text="{x:Bind helper:Locale.Lang._GameSettingsPage.Graphics_Reflection}" Style="{ThemeResource BodyStrongTextBlockStyle}" Margin="0,0,0,8"/>
-                                        <ComboBox x:Name="ReflectionQualitySelector" Margin="0,8,0,8" Width="128"
+                                        <ComboBox x:Name="ReflectionQualitySelector" Margin="0,0,0,8" Width="128"
                                                   SelectedIndex="{x:Bind GraphicsReflectionQuality, Mode=TwoWay}" CornerRadius="14">
                                             <ComboBoxItem Content="{x:Bind helper:Locale.Lang._GameSettingsPage.SpecDisabled}"/>
                                             <ComboBoxItem Content="{x:Bind helper:Locale.Lang._GameSettingsPage.SpecLow}"/>
@@ -158,8 +158,8 @@
                                         </ComboBox>
                                     </StackPanel>
                                 </Grid>
-                                <TextBlock Text="{x:Bind helper:Locale.Lang._GameSettingsPage.Graphics_FX}" Style="{ThemeResource BodyStrongTextBlockStyle}" Margin="0,16,0,8"/>
-                                <Expander Margin="0,8,0,8" MaxWidth="514" HorizontalContentAlignment="Stretch" CornerRadius="8"
+                                <TextBlock Text="{x:Bind helper:Locale.Lang._GameSettingsPage.Graphics_FX}" Style="{ThemeResource BodyStrongTextBlockStyle}" Margin="0,8,0,8"/>
+                                <Expander Margin="0,0,0,8" MaxWidth="514" HorizontalContentAlignment="Stretch" CornerRadius="8"
                                    x:Name="GameFXPostProcExpander" IsExpanded="{x:Bind IsGraphicsPostFXEnabled, Mode=OneWay}">
                                     <Expander.Header>
                                         <StackPanel Orientation="Horizontal">
@@ -201,7 +201,7 @@
                                     </Expander.Content>
                                 </Expander>
                             </StackPanel>
-                            <TextBlock Text="{x:Bind helper:Locale.Lang._GameSettingsPage.Graphics_APHO2Panel}" Style="{ThemeResource SubtitleTextBlockStyle}" Margin="0,16,0,16"/>
+                            <TextBlock Text="{x:Bind helper:Locale.Lang._GameSettingsPage.Graphics_APHO2Panel}" Style="{ThemeResource SubtitleTextBlockStyle}" Margin="0,8,0,16"/>
                             <StackPanel>
                                 <Grid>
                                     <Grid.ColumnDefinitions>
@@ -255,17 +255,17 @@
                             </StackPanel>
                         </StackPanel>
                     </Grid>
-                    <MenuFlyoutSeparator Margin="0,48"/>
-                    <TextBlock Text="{x:Bind helper:Locale.Lang._GameSettingsPage.Audio_Title}" Style="{ThemeResource TitleLargeTextBlockStyle}" Margin="0,0,0,16"/>
+                    <MenuFlyoutSeparator Margin="0,4,0,8"/>
+                    <TextBlock Text="{x:Bind helper:Locale.Lang._GameSettingsPage.Audio_Title}" Style="{ThemeResource TitleLargeTextBlockStyle}" Margin="0,0,0,8"/>
                     <Grid>
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition/>
                             <ColumnDefinition/>
                         </Grid.ColumnDefinitions>
                         <StackPanel Grid.Column="0">
-                            <StackPanel x:Name="AudioSettingsPanelLeft" Margin="0,16,64,16">
+                            <StackPanel x:Name="AudioSettingsPanelLeft" Margin="0,8,64,16">
                                 <StackPanel>
-                                    <TextBlock Text="{x:Bind helper:Locale.Lang._GameSettingsPage.Audio_Master}" Style="{ThemeResource SubtitleTextBlockStyle}" Margin="0,0,0,16"/>
+                                    <TextBlock Text="{x:Bind helper:Locale.Lang._GameSettingsPage.Audio_Master}" Style="{ThemeResource SubtitleTextBlockStyle}" Margin="0,0,0,8"/>
                                     <StackPanel Orientation="Vertical" Margin="0,0,32,8">
                                         <Grid>
                                             <Grid.ColumnDefinitions>
@@ -279,7 +279,7 @@
                                     </StackPanel>
                                 </StackPanel>
                                 <StackPanel>
-                                    <TextBlock Text="{x:Bind helper:Locale.Lang._GameSettingsPage.Audio_BGM}" Style="{ThemeResource SubtitleTextBlockStyle}" Margin="0,16,0,16"/>
+                                    <TextBlock Text="{x:Bind helper:Locale.Lang._GameSettingsPage.Audio_BGM}" Style="{ThemeResource SubtitleTextBlockStyle}" Margin="0,16,0,8"/>
                                     <StackPanel Orientation="Vertical" Margin="0,0,32,8">
                                         <Grid>
                                             <Grid.ColumnDefinitions>
@@ -293,7 +293,7 @@
                                     </StackPanel>
                                 </StackPanel>
                                 <StackPanel>
-                                    <TextBlock Text="{x:Bind helper:Locale.Lang._GameSettingsPage.Audio_SFX}" Style="{ThemeResource SubtitleTextBlockStyle}" Margin="0,16,0,16"/>
+                                    <TextBlock Text="{x:Bind helper:Locale.Lang._GameSettingsPage.Audio_SFX}" Style="{ThemeResource SubtitleTextBlockStyle}" Margin="0,16,0,8"/>
                                     <StackPanel Orientation="Vertical" Margin="0,0,32,8">
                                         <Grid>
                                             <Grid.ColumnDefinitions>
@@ -313,7 +313,7 @@
                                             <ColumnDefinition/>
                                         </Grid.ColumnDefinitions>
                                         <StackPanel>
-                                            <TextBlock Text="{x:Bind helper:Locale.Lang._GameSettingsPage.Audio_VOLang}" Style="{ThemeResource SubtitleTextBlockStyle}" Margin="0,16,0,16"/>
+                                            <TextBlock Text="{x:Bind helper:Locale.Lang._GameSettingsPage.Audio_VOLang}" Style="{ThemeResource SubtitleTextBlockStyle}" Margin="0,8,0,8"/>
                                             <ComboBox x:Name="AudioCVLanguageSelector" Width="172" CornerRadius="14"
                                                 SelectedIndex="{x:Bind AudioVoiceLanguage, Mode=TwoWay}">
                                                 <ComboBoxItem Content="{x:Bind helper:Locale.Lang._GameSettingsPage.Audio_VOLang1}"/>
@@ -323,7 +323,7 @@
                                             </ComboBox>
                                         </StackPanel>
                                         <StackPanel Grid.Column="1">
-                                            <TextBlock Text="{x:Bind helper:Locale.Lang._GameSettingsPage.Audio_Mute}" Style="{ThemeResource SubtitleTextBlockStyle}" Margin="0,16,0,10"/>
+                                            <TextBlock Text="{x:Bind helper:Locale.Lang._GameSettingsPage.Audio_Mute}" Style="{ThemeResource SubtitleTextBlockStyle}" Margin="0,8,0,4"/>
                                             <ToggleSwitch OnContent="{x:Bind helper:Locale.Lang._Misc.Enabled}" OffContent="{x:Bind helper:Locale.Lang._Misc.Disabled}" IsOn="{x:Bind AudioMute, Mode=TwoWay}"/>
                                         </StackPanel>
                                     </Grid>
@@ -331,9 +331,9 @@
                             </StackPanel>
                         </StackPanel>
                         <StackPanel Grid.Column="1">
-                            <StackPanel x:Name="AudioSettingsPanelRight" Margin="0,16,64,16">
+                            <StackPanel x:Name="AudioSettingsPanelRight" Margin="0,8,64,16">
                                 <StackPanel>
-                                    <TextBlock Text="{x:Bind helper:Locale.Lang._GameSettingsPage.Audio_VO}" Style="{ThemeResource SubtitleTextBlockStyle}" Margin="0,0,0,16"/>
+                                    <TextBlock Text="{x:Bind helper:Locale.Lang._GameSettingsPage.Audio_VO}" Style="{ThemeResource SubtitleTextBlockStyle}" Margin="0,0,0,8"/>
                                     <StackPanel Orientation="Vertical" Margin="0,0,32,8">
                                         <Grid>
                                             <Grid.ColumnDefinitions>
@@ -347,7 +347,7 @@
                                     </StackPanel>
                                 </StackPanel>
                                 <StackPanel>
-                                    <TextBlock Text="{x:Bind helper:Locale.Lang._GameSettingsPage.Audio_Elf}" Style="{ThemeResource SubtitleTextBlockStyle}" Margin="0,16,0,16"/>
+                                    <TextBlock Text="{x:Bind helper:Locale.Lang._GameSettingsPage.Audio_Elf}" Style="{ThemeResource SubtitleTextBlockStyle}" Margin="0,16,0,8"/>
                                     <StackPanel Orientation="Vertical" Margin="0,0,32,8">
                                         <Grid>
                                             <Grid.ColumnDefinitions>
@@ -361,7 +361,7 @@
                                     </StackPanel>
                                 </StackPanel>
                                 <StackPanel>
-                                    <TextBlock Text="{x:Bind helper:Locale.Lang._GameSettingsPage.Audio_Cutscenes}" Style="{ThemeResource SubtitleTextBlockStyle}" Margin="0,16,0,16"/>
+                                    <TextBlock Text="{x:Bind helper:Locale.Lang._GameSettingsPage.Audio_Cutscenes}" Style="{ThemeResource SubtitleTextBlockStyle}" Margin="0,16,0,8"/>
                                     <StackPanel Orientation="Vertical" Margin="0,0,32,8">
                                         <Grid>
                                             <Grid.ColumnDefinitions>
@@ -377,7 +377,7 @@
                             </StackPanel>
                         </StackPanel>
                     </Grid>
-                    <MenuFlyoutSeparator Margin="0,48"/>
+                    <MenuFlyoutSeparator Margin="0,4,0,8"/>
                     <TextBlock Text="{x:Bind helper:Locale.Lang._GameSettingsPage.CustomArgs_Title}" Style="{ThemeResource TitleLargeTextBlockStyle}" Margin="0,0,0,16"/>
                     <TextBlock Text="{x:Bind helper:Locale.Lang._GameSettingsPage.CustomArgs_Subtitle}" Style="{ThemeResource SubtitleTextBlockStyle}" Margin="0,0,0,16"/>
                     <TextBox x:Name="CustomArgsTextBox" Text="{x:Bind CustomArgsValue, Mode=TwoWay}" CornerRadius="8,8,0,0"

--- a/CollapseLauncher/XAMLs/MainApp/Pages/GenshinGameSettingsPage.xaml
+++ b/CollapseLauncher/XAMLs/MainApp/Pages/GenshinGameSettingsPage.xaml
@@ -79,7 +79,7 @@
                                 <StackPanel>
                                     <Grid x:Name="GammaGrid">
                                         <TextBlock Text="{x:Bind helper:Locale.Lang._GenshinGameSettingsPage.Graphics_Gamma}" Style="{ThemeResource BodyStrongTextBlockStyle}"/>
-                                        <NumberBox Name="GammaValue" Minimum="1.4" Maximum="3.0" HorizontalAlignment="Right" Width="80" ValueChanged="GammaValue_ValueChanged" NumberFormatter="{StaticResource DecimalFormatter}" CornerRadius="8,8,0,0" Margin="0,0,28,0"/>
+                                        <NumberBox Name="GammaValue" Minimum="1.4" Maximum="3.0" HorizontalAlignment="Right" Width="110" ValueChanged="GammaValue_ValueChanged" NumberFormatter="{StaticResource DecimalFormatter}" CornerRadius="8,8,0,0" Margin="0,0,28,0"/>
                                     </Grid>
                                     <Slider x:Name="GammaSlider" Minimum="1.4" Maximum="3.0" Value="{x:Bind Gamma, Mode=TwoWay}"  TickFrequency="0.2" StepFrequency="0.000001" TickPlacement="Outside" Margin="0,0,28,8" IsThumbToolTipEnabled="False" ValueChanged="GammaSlider_ValueChanged"/>
                                 </StackPanel>

--- a/CollapseLauncher/XAMLs/MainApp/Pages/GenshinGameSettingsPage.xaml
+++ b/CollapseLauncher/XAMLs/MainApp/Pages/GenshinGameSettingsPage.xaml
@@ -80,9 +80,9 @@
                                 <StackPanel>
                                     <Grid x:Name="GammaGrid">
                                         <TextBlock Text="{x:Bind helper:Locale.Lang._GenshinGameSettingsPage.Graphics_Gamma}" Style="{ThemeResource BodyStrongTextBlockStyle}"/>
-                                        <NumberBox Name="GammaValue" Minimum="1.4" Maximum="3.0" HorizontalAlignment="Right" Width="80" ValueChanged="GammaValue_ValueChanged" NumberFormatter="{StaticResource DecimalFormatter}" CornerRadius="8,8,0,0" Margin="0,0,56,0"/>
+                                        <NumberBox Name="GammaValue" Minimum="1.4" Maximum="3.0" HorizontalAlignment="Right" Width="80" ValueChanged="GammaValue_ValueChanged" NumberFormatter="{StaticResource DecimalFormatter}" CornerRadius="8,8,0,0" Margin="0,0,28,0"/>
                                     </Grid>
-                                    <Slider x:Name="GammaSlider" Minimum="1.4" Maximum="3.0" Value="{x:Bind Gamma, Mode=TwoWay}"  TickFrequency="0.2" StepFrequency="0.000001" TickPlacement="Outside" Margin="0,0,56,8" IsThumbToolTipEnabled="False" ValueChanged="GammaSlider_ValueChanged"/>
+                                    <Slider x:Name="GammaSlider" Minimum="1.4" Maximum="3.0" Value="{x:Bind Gamma, Mode=TwoWay}"  TickFrequency="0.2" StepFrequency="0.000001" TickPlacement="Outside" Margin="0,0,28,8" IsThumbToolTipEnabled="False" ValueChanged="GammaSlider_ValueChanged"/>
                                 </StackPanel>
                                 <StackPanel>
                                     <Grid>
@@ -210,7 +210,7 @@
                                     </StackPanel>
                                 </Grid>
                             </StackPanel>
-                            <StackPanel Margin="0,8,0,0">
+                            <StackPanel Margin="0,8,0,8">
                                 <Grid>
                                     <Grid.ColumnDefinitions>
                                         <ColumnDefinition/>
@@ -349,7 +349,7 @@
                                 <StackPanel Grid.Column="1" x:Name="LangSettingRight">
                                     <StackPanel>
                                         <TextBlock Text="{x:Bind helper:Locale.Lang._GenshinGameSettingsPage.LanguageText}" Style="{ThemeResource BodyStrongTextBlockStyle}" Margin="-80,0,0,8"/>
-                                        <ComboBox x:Name="TextLangSelector" Margin="-80,0,0,16" Width="128" CornerRadius="14" SelectedIndex="{x:Bind TextLang, Mode=TwoWay}">
+                                        <ComboBox x:Name="TextLangSelector" Margin="-80,0,0,16" Width="128" CornerRadius="14" SelectedIndex="{x:Bind TextLang, Mode=TwoWay}" MaxDropDownHeight="200">
                                             <ComboBoxItem Content="English"/>
                                             <ComboBoxItem Content="简体中文"/>
                                             <ComboBoxItem Content="繁體中文"/>

--- a/CollapseLauncher/XAMLs/MainApp/Pages/GenshinGameSettingsPage.xaml
+++ b/CollapseLauncher/XAMLs/MainApp/Pages/GenshinGameSettingsPage.xaml
@@ -12,8 +12,7 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:f="using:Windows.Globalization.NumberFormatting"
     mc:Ignorable="d"
-    Loaded="InitializeSettings"
-    Unloaded="OnUnload">
+    Loaded="InitializeSettings" Unloaded="OnUnload">
     <Page.Resources>
         <ThemeShadow x:Name="SharedShadow"/>
         <conv:InverseBooleanConverter x:Key="BooleanInverse"/>

--- a/CollapseLauncher/XAMLs/MainApp/Pages/GenshinGameSettingsPage.xaml
+++ b/CollapseLauncher/XAMLs/MainApp/Pages/GenshinGameSettingsPage.xaml
@@ -80,7 +80,7 @@
                                 <StackPanel>
                                     <Grid x:Name="GammaGrid">
                                         <TextBlock Text="{x:Bind helper:Locale.Lang._GenshinGameSettingsPage.Graphics_Gamma}" Style="{ThemeResource BodyStrongTextBlockStyle}"/>
-                                        <NumberBox Name="GammaValue" Minimum="1.4" Maximum="3.0" HorizontalAlignment="Right" Width="200" ValueChanged="GammaValue_ValueChanged" NumberFormatter="{StaticResource DecimalFormatter}"/>
+                                        <NumberBox Name="GammaValue" Minimum="1.4" Maximum="3.0" HorizontalAlignment="Right" Width="80" ValueChanged="GammaValue_ValueChanged" NumberFormatter="{StaticResource DecimalFormatter}" CornerRadius="8,8,0,0" Margin="0,0,56,0"/>
                                     </Grid>
                                     <Slider x:Name="GammaSlider" Minimum="1.4" Maximum="3.0" Value="{x:Bind Gamma, Mode=TwoWay}"  TickFrequency="0.2" StepFrequency="0.000001" TickPlacement="Outside" Margin="0,0,56,8" IsThumbToolTipEnabled="False" ValueChanged="GammaSlider_ValueChanged"/>
                                 </StackPanel>

--- a/CollapseLauncher/XAMLs/MainApp/Pages/GenshinGameSettingsPage.xaml.cs
+++ b/CollapseLauncher/XAMLs/MainApp/Pages/GenshinGameSettingsPage.xaml.cs
@@ -220,16 +220,33 @@ namespace CollapseLauncher.Pages
         /// <param name="args"></param>
         private void GammaValue_ValueChanged(NumberBox sender, NumberBoxValueChangedEventArgs args)
         {
-            IncrementNumberRounder rounder = new IncrementNumberRounder();
-            rounder.Increment = 0.0000001;
+            try
+            {
+                // Check if NumberBox is cleared (NaN) then reuse old value
+                // Why is this not the default behavior instead of throwing errors? I don't know ask Microsoft
+                if (double.IsNaN(args.NewValue))
+                {
+                    LogWriteLine($"Gamma value from NumberBox is invalid, resetting it to last value: {args.OldValue}", LogType.Warning, false);
+                    GammaValue.Value = args.OldValue;
+                }
+                else
+                {
+                    IncrementNumberRounder rounder = new IncrementNumberRounder();
+                    rounder.Increment = 0.0000001;
 
-            DecimalFormatter formatter = new DecimalFormatter();
-            formatter.IntegerDigits = 1;
-            formatter.FractionDigits = 5;
-            formatter.NumberRounder = rounder;
+                    DecimalFormatter formatter = new DecimalFormatter();
+                    formatter.IntegerDigits = 1;
+                    formatter.FractionDigits = 5;
+                    formatter.NumberRounder = rounder;
+                    GammaValue.NumberFormatter = formatter;
 
-            GammaValue.NumberFormatter = formatter;
-            GammaSlider.Value = GammaValue.Value;
+                    GammaSlider.Value = GammaValue.Value;
+                }
+            }
+            catch (Exception ex)
+            {
+                LogWriteLine($"Error when processing Gamma NumberBox!\r\n{ex}", LogType.Error, true);
+            }
         }
 
         /// <summary>

--- a/CollapseLauncher/XAMLs/MainApp/Pages/GenshinGameSettingsPage.xaml.cs
+++ b/CollapseLauncher/XAMLs/MainApp/Pages/GenshinGameSettingsPage.xaml.cs
@@ -212,6 +212,12 @@ namespace CollapseLauncher.Pages
             });
         }
 
+        /// <summary>
+        /// This updates Gamma Slider every time GammaNumber is entered.
+        /// Do NOT touch this unless really necessary to do so!
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="args"></param>
         private void GammaValue_ValueChanged(NumberBox sender, NumberBoxValueChangedEventArgs args)
         {
             IncrementNumberRounder rounder = new IncrementNumberRounder();
@@ -223,8 +229,15 @@ namespace CollapseLauncher.Pages
             formatter.NumberRounder = rounder;
 
             GammaValue.NumberFormatter = formatter;
+            GammaSlider.Value = GammaValue.Value;
         }
 
+        /// <summary>
+        /// This updates Gamma NumberBox when slider is moved.
+        /// no touchy :)
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
         private void GammaSlider_ValueChanged(object sender,  RangeBaseValueChangedEventArgs e)
         {
             GammaValue.Value = Math.Round(e.NewValue, 5);

--- a/CollapseLauncher/XAMLs/MainApp/Pages/SettingsPage.xaml
+++ b/CollapseLauncher/XAMLs/MainApp/Pages/SettingsPage.xaml
@@ -26,7 +26,7 @@
                         <TextBlock x:Name="ChangeRegionToggleWarning" Visibility="Collapsed" Text="{x:Bind helper:Locale.Lang._SettingsPage.ChangeRegionWarning_Warning}" Margin="0,0,0,8" FontWeight="Bold" Foreground="{ThemeResource AccentColor}"/>
                         <StackPanel Margin="0,0,0,16">
                             <TextBlock Text="{x:Bind helper:Locale.Lang._SettingsPage.Language}" Style="{ThemeResource SubtitleTextBlockStyle}" Margin="0,16,0,16"/>
-                            <ComboBox x:Name="LanguageSelector" MinWidth="256" CornerRadius="14" ItemsSource="{x:Bind LanguageList}" SelectedIndex="{x:Bind LanguageSelectedIndex, Mode=TwoWay}"/>
+                            <ComboBox x:Name="LanguageSelector" MinWidth="256" CornerRadius="14" ItemsSource="{x:Bind LanguageList}" SelectedIndex="{x:Bind LanguageSelectedIndex, Mode=TwoWay}" MaxDropDownHeight="200"/>
                             <TextBlock x:Name="AppLangSelectionWarning" Visibility="Collapsed" Text="{x:Bind helper:Locale.Lang._SettingsPage.AppLang_ApplyNeedRestart}" Margin="0,16,0,0" FontWeight="Bold" Foreground="{ThemeResource AccentColor}"/>
                         </StackPanel>
                         <TextBlock Text="{x:Bind helper:Locale.Lang._SettingsPage.AppThemes}" Style="{ThemeResource SubtitleTextBlockStyle}" Margin="0,16,0,16"/>

--- a/CollapseLauncher/XAMLs/MainApp/Pages/StarRailGameSettingsPage.xaml
+++ b/CollapseLauncher/XAMLs/MainApp/Pages/StarRailGameSettingsPage.xaml
@@ -291,7 +291,7 @@
                                 <StackPanel Grid.Column="1" x:Name="LangSettingRight">
                                     <StackPanel>
                                         <TextBlock Text="{x:Bind helper:Locale.Lang._StarRailGameSettingsPage.LanguageText}" Style="{ThemeResource BodyStrongTextBlockStyle}" Margin="-80,0,0,8"/>
-                                        <ComboBox x:Name="TextLangSelector" Margin="-80,0,0,16" Width="128" CornerRadius="14" SelectedIndex="{x:Bind TextLang, Mode=TwoWay}">
+                                        <ComboBox x:Name="TextLangSelector" Margin="-80,0,0,16" Width="128" CornerRadius="14" SelectedIndex="{x:Bind TextLang, Mode=TwoWay}" MaxDropDownHeight="200">
                                             <ComboBoxItem Content="English"/>
                                             <ComboBoxItem Content="日本語"/>
                                             <ComboBoxItem Content="简体中文"/>

--- a/Hi3Helper.Core/Lang/Locale/LangMisc.cs
+++ b/Hi3Helper.Core/Lang/Locale/LangMisc.cs
@@ -79,6 +79,7 @@
                 public string CDNDescription_Statically { get; set; } = LangFallback?._Misc.CDNDescription_Statically;
                 public string CDNDescription_jsDelivr { get; set; } = LangFallback?._Misc.CDNDescription_jsDelivr;
                 public string LocateExecutable { get; set; } = LangFallback?._Misc.LocateExecutable;
+                public string OpenDownloadPage { get; set; } = LangFallback?._Misc.OpenDownloadPage;
                 public string DiscordRP_Play { get; set; } = LangFallback?._Misc.DiscordRP_Play;
                 public string DiscordRP_Update { get; set; } = LangFallback?._Misc.DiscordRP_Update;
                 public string DiscordRP_Repair { get; set; } = LangFallback?._Misc.DiscordRP_Repair;

--- a/Hi3Helper.Core/Lang/en-us.json
+++ b/Hi3Helper.Core/Lang/en-us.json
@@ -456,6 +456,7 @@
     "CDNDescription_jsDelivr": "jsDelivr uses multiple CDN providers like CloudFlare, Fastly and Quantil, resulting in the best possible uptime and performance.",
 
     "LocateExecutable": "Locate Program Executable",
+    "OpenDownloadPage": "Open Download Page",
 
     "DiscordRP_Play": "Playing",
     "DiscordRP_Update": "Updating",

--- a/Hi3Helper.Core/Lang/en-us.json
+++ b/Hi3Helper.Core/Lang/en-us.json
@@ -97,7 +97,7 @@
     "PreloadDownloadNotifbarVerifyTitle": "Verifying Pre-load Package",
     "PreloadDownloadNotifbarSubtitle": "Mandatory Package",
     "UpdatingVoicePack": "Updating Voice Pack...",
-    "InstallBtn": "Install Game",
+    "InstallBtn": "Install/Locate Game",
     "UpdateBtn": "Update Game",
     "PauseDownloadBtn": "Pause",
     "ResumeDownloadBtn": "Resume",


### PR DESCRIPTION
- Fixed GI GameSettings: Gamma NumberBox appearance
- Added debug logger to Hi3 Settings and Collapse ScreenSettings
- Added missing exception catch on HI3 GameSettings
- Corrected debug loggers
- Fixed GI GameSettings RegistryWatcher not getting unsubscribed
- Adjusted `Install Game` button as `Install/Locate Game` (closes #150)
- Adjusted drop down height for big language selectors
- Adjusted margins on Game Settings page for HI3 and GI
- Changed Community Tool `Cancel` button for executable tools as `Open Download Page` following its actual behavior
- Fixed Gamma slider not updated when Gamma NumberBox is entered
- Fixed crashing when Gamma NumberBox is cleared