### PR TITLE
App Settings and Discord RPC Improvements

### DIFF
--- a/CollapseLauncher/Classes/Properties/InnerLauncherConfig.cs
+++ b/CollapseLauncher/Classes/Properties/InnerLauncherConfig.cs
@@ -173,6 +173,11 @@ namespace CollapseLauncher
                     await FallbackCDNUtil.DownloadCDNFallbackContent(_http, s, string.Format(AppGameConfigV2URLPrefix, (IsPreview ? "preview" : "stable") + "stamp"), default).ConfigureAwait(false);
                     s.Position = 0;
                     ConfigStamp = (Stamp)JsonSerializer.Deserialize(s, typeof(Stamp), StampContext.Default);
+#if DEBUG
+                    LogWriteLine($"Checking for metadata update...\r\n" +
+                        $"  LocalStamp  : {ConfigV2LastUpdate}\r\n" +
+                        $"  RemoteStamp : {ConfigStamp?.LastUpdated}", LogType.Warning, true);
+#endif
                 }
             }
             catch (Exception ex)
@@ -181,7 +186,7 @@ namespace CollapseLauncher
                 return false;
             }
 
-            return ConfigV2LastUpdate != ConfigStamp?.LastUpdated;
+            return ConfigV2LastUpdate < ConfigStamp?.LastUpdated;
         }
 
         public static async Task DownloadConfigV2Files(bool Stamp, bool Content)

--- a/CollapseLauncher/Classes/RegistryMonitor/RegistryMonitor.cs
+++ b/CollapseLauncher/Classes/RegistryMonitor/RegistryMonitor.cs
@@ -15,6 +15,7 @@ using System.IO;
 using System.Threading;
 using System.Runtime.InteropServices;
 using Microsoft.Win32;
+using static Hi3Helper.Logger;
 
 namespace RegistryUtils
 {
@@ -144,6 +145,11 @@ namespace RegistryUtils
         public RegistryMonitor(RegistryHive registryHive, string subKey)
         {
             InitRegistryKey(registryHive, subKey);
+#if DEBUG
+            LogWriteLine($"RegistryMonitor Initialized!\r\n" +
+                $"  Hive: {registryHive}\r\n" +
+                $"  subKey: {subKey}", Hi3Helper.LogType.Debug, true);
+#endif
         }
 
         /// <summary>
@@ -154,6 +160,9 @@ namespace RegistryUtils
             Stop();
             _disposed = true;
             GC.SuppressFinalize(this);
+#if DEBUG
+            LogWriteLine($"RegistryMonitor Disposed!", Hi3Helper.LogType.Debug, true);
+#endif
         }
 
         /// <summary>
@@ -333,6 +342,11 @@ namespace RegistryUtils
 
                     if (WaitHandle.WaitAny(waitHandles) == 0)
                     {
+#if DEBUG
+                        LogWriteLine($"[RegistryMonitor] Found change(s) in registry!\r\n" +
+                            $"  Hive: {_registryHive}\r\n" +
+                            $"  subName: {_registrySubName}", Hi3Helper.LogType.Debug, true);
+#endif
                         OnRegChanged();
                     }
                 }

--- a/CollapseLauncher/XAMLs/MainApp/Pages/GameSettingsPage.xaml.cs
+++ b/CollapseLauncher/XAMLs/MainApp/Pages/GameSettingsPage.xaml.cs
@@ -59,7 +59,7 @@ namespace CollapseLauncher.Pages
         {
             if (!IsNoReload)
             {
-                LogWriteLine("Module: RegistryMonitor has detected registry change outside of the launcher! Reloading the page...", LogType.Warning, true);
+                LogWriteLine("[HI3 GSP Module] RegistryMonitor has detected registry change outside of the launcher! Reloading the page...", LogType.Warning, true);
                 DispatcherQueue.TryEnqueue(MainFrameChanger.ReloadCurrentMainFrame);
             }
         }

--- a/CollapseLauncher/XAMLs/MainApp/Pages/GenshinGameSettingsPage.xaml.cs
+++ b/CollapseLauncher/XAMLs/MainApp/Pages/GenshinGameSettingsPage.xaml.cs
@@ -63,7 +63,7 @@ namespace CollapseLauncher.Pages
         {
             if (!IsNoReload)
             {
-                LogWriteLine("Module: RegistryMonitor has detected registry change outside of the launcher! Reloading the page...", LogType.Warning, true);
+                LogWriteLine("[GI GSP Module] RegistryMonitor has detected registry change outside of the launcher! Reloading the page...", LogType.Warning, true);
                 DispatcherQueue.TryEnqueue(MainFrameChanger.ReloadCurrentMainFrame);
             }
         }

--- a/CollapseLauncher/XAMLs/MainApp/Pages/HomePage.xaml.cs
+++ b/CollapseLauncher/XAMLs/MainApp/Pages/HomePage.xaml.cs
@@ -1032,6 +1032,7 @@ namespace CollapseLauncher.Pages
 
             string line;
             int barwidth = ((consoleWidth - 22) / 2) - 1;
+            LogWriteLine($"Is Game logs gets saved to Collapse's logs: {GetAppConfigValue("IncludeGameLogs").ToBool()}", LogType.Scheme, true);
             LogWriteLine($"{new string('=', barwidth)} GAME STARTED {new string('=', barwidth)}", LogType.Warning, true);
             try
             {
@@ -1054,7 +1055,7 @@ namespace CollapseLauncher.Pages
                                 StartExclusiveWindowPayload();
                                 RequireWindowExclusivePayload = false;
                             }
-                            LogWriteLine(line, LogType.Game, true);
+                            LogWriteLine(line, LogType.Game, GetAppConfigValue("IncludeGameLogs").ToBool());
                         }
                         await Task.Delay(100, WatchOutputLog.Token);
                     }

--- a/CollapseLauncher/XAMLs/MainApp/Pages/SettingsPage.xaml
+++ b/CollapseLauncher/XAMLs/MainApp/Pages/SettingsPage.xaml
@@ -15,30 +15,42 @@
                 <ColumnDefinition Width="350"/>
             </Grid.ColumnDefinitions>
             <StackPanel HorizontalAlignment="Left" Grid.Column="0">
-                <TextBlock Text="{x:Bind helper:Locale.Lang._SettingsPage.PageTitle}" Style="{ThemeResource TitleLargeTextBlockStyle}" Margin="0,0,0,16"/>
-                <StackPanel x:Name="AppSettings" Margin="0,16" HorizontalAlignment="Left">
+                <TextBlock Text="{x:Bind helper:Locale.Lang._SettingsPage.PageTitle}" Style="{ThemeResource TitleLargeTextBlockStyle}" Margin="0,0,0,0"/>
+                <StackPanel x:Name="AppSettings" Margin="0,8" HorizontalAlignment="Left">
                     <StackPanel>
-                        <TextBlock Text="{x:Bind helper:Locale.Lang._SettingsPage.Debug}" Style="{ThemeResource SubtitleTextBlockStyle}" Margin="0,0,0,16"/>
-                        <ToggleSwitch Header="{x:Bind helper:Locale.Lang._SettingsPage.Debug_Console}" OffContent="{x:Bind helper:Locale.Lang._Misc.Disabled}" OnContent="{x:Bind helper:Locale.Lang._Misc.Enabled}" Margin="0,4" IsOn="{x:Bind IsConsoleEnabled, Mode=TwoWay}"/>
-                        <ToggleSwitch Header="{x:Bind helper:Locale.Lang._SettingsPage.Debug_MultipleInstance}" OffContent="{x:Bind helper:Locale.Lang._Misc.Disabled}" OnContent="{x:Bind helper:Locale.Lang._Misc.Enabled}" Margin="0,4" IsOn="{x:Bind IsMultipleInstanceEnabled, Mode=TwoWay}"/>
-                        <ToggleSwitch Header="{x:Bind helper:Locale.Lang._SettingsPage.ChangeRegionWarning_Toggle}" OffContent="{x:Bind helper:Locale.Lang._Misc.Disabled}" OnContent="{x:Bind helper:Locale.Lang._Misc.Enabled}" Margin="0,4" IsOn="{x:Bind IsShowRegionChangeWarning, Mode=TwoWay}"/>
-                        <TextBlock x:Name="ChangeRegionToggleWarning" Visibility="Collapsed" Text="{x:Bind helper:Locale.Lang._SettingsPage.ChangeRegionWarning_Warning}" Margin="0,0,0,8" FontWeight="Bold" Foreground="{ThemeResource AccentColor}"/>
-                        <StackPanel Margin="0,0,0,16">
-                            <TextBlock Text="{x:Bind helper:Locale.Lang._SettingsPage.Language}" Style="{ThemeResource SubtitleTextBlockStyle}" Margin="0,16,0,16"/>
-                            <ComboBox x:Name="LanguageSelector" MinWidth="256" CornerRadius="14" ItemsSource="{x:Bind LanguageList}" SelectedIndex="{x:Bind LanguageSelectedIndex, Mode=TwoWay}" MaxDropDownHeight="200"/>
-                            <TextBlock x:Name="AppLangSelectionWarning" Visibility="Collapsed" Text="{x:Bind helper:Locale.Lang._SettingsPage.AppLang_ApplyNeedRestart}" Margin="0,16,0,0" FontWeight="Bold" Foreground="{ThemeResource AccentColor}"/>
+                        <StackPanel Margin="0,0,0,8">
+                            <TextBlock Text="{x:Bind helper:Locale.Lang._SettingsPage.Language}" Style="{ThemeResource SubtitleTextBlockStyle}" Margin="0,10,0,8"/>
+                            <ComboBox x:Name="LanguageSelector" MinWidth="256" CornerRadius="14" ItemsSource="{x:Bind LanguageList}" SelectedIndex="{x:Bind LanguageSelectedIndex, Mode=TwoWay}" MaxDropDownHeight="200" Margin="8,0"/>
+                            <TextBlock x:Name="AppLangSelectionWarning" Visibility="Collapsed" Text="{x:Bind helper:Locale.Lang._SettingsPage.AppLang_ApplyNeedRestart}" FontWeight="Bold" Foreground="{ThemeResource AccentColor}" Margin="8,4,0,0"/>
                         </StackPanel>
-                        <TextBlock Text="{x:Bind helper:Locale.Lang._SettingsPage.AppThemes}" Style="{ThemeResource SubtitleTextBlockStyle}" Margin="0,16,0,16"/>
-                        <StackPanel Margin="0,-8,0,16">
-                            <RadioButtons x:Name="AppThemeSelection" SelectedIndex="{x:Bind CurrentThemeSelection, Mode=TwoWay}">
+                        <TextBlock Text="{x:Bind helper:Locale.Lang._SettingsPage.AppThemes}" Style="{ThemeResource SubtitleTextBlockStyle}" Margin="0,10,0,4"/>
+                        <StackPanel Margin="0,-8,0,8">
+                            <RadioButtons x:Name="AppThemeSelection" SelectedIndex="{x:Bind CurrentThemeSelection, Mode=TwoWay}" Margin="8,0">
                                 <RadioButton Content="{x:Bind helper:Locale.Lang._SettingsPage.AppThemes_Default}"/>
                                 <RadioButton Content="{x:Bind helper:Locale.Lang._SettingsPage.AppThemes_Light}"/>
                                 <RadioButton Content="{x:Bind helper:Locale.Lang._SettingsPage.AppThemes_Dark}"/>
                             </RadioButtons>
-                            <TextBlock x:Name="AppThemeSelectionWarning" Visibility="Collapsed" Text="{x:Bind helper:Locale.Lang._SettingsPage.AppThemes_ApplyNeedRestart}" Margin="0,16,0,0" FontWeight="Bold" Foreground="{ThemeResource AccentColor}"/>
+                            <TextBlock x:Name="AppThemeSelectionWarning" Visibility="Collapsed" Text="{x:Bind helper:Locale.Lang._SettingsPage.AppThemes_ApplyNeedRestart}" FontWeight="Bold" Foreground="{ThemeResource AccentColor}" Margin="8,0"/>
                         </StackPanel>
-                        <TextBlock Text="{x:Bind helper:Locale.Lang._SettingsPage.AppWindowSize}" Style="{ThemeResource SubtitleTextBlockStyle}" Margin="0,16,0,16"/>
-                        <StackPanel Margin="0,-8,0,16">
+                        <StackPanel Margin="8,0,0,8" HorizontalAlignment="Left">
+                            <CheckBox x:Name="AppBGMode" Content="{x:Bind helper:Locale.Lang._SettingsPage.AppBG_Checkbox}" IsChecked="{x:Bind IsBGCustom, Mode=TwoWay}"/>
+                            <StackPanel x:Name="AppBGCustomizer" Orientation="Horizontal" Margin="-2,8,0,0" Visibility="Collapsed">
+                                <Button x:Name="BGSelector" IsEnabled="False" Margin="-40,0,0,0" CornerRadius="0,16,16,0" Click="SelectBackgroundImg" Style="{ThemeResource AccentButtonStyle}">
+                                    <StackPanel Orientation="Horizontal" Margin="32,0,0,0">
+                                        <TextBlock FontFamily="{ThemeResource FontAwesome}" Text="&#xF03E;" FontSize="22"/>
+                                        <TextBlock Text="{x:Bind helper:Locale.Lang._Misc.Select}" Margin="8,0,0,0" FontWeight="Medium" VerticalAlignment="Center"/>
+                                    </StackPanel>
+                                </Button>
+                                <TextBlock x:Name="BGPathDisplay" Text="" VerticalAlignment="Center" Width="384" Margin="12,0,0,0" TextTrimming="CharacterEllipsis"/>
+                            </StackPanel>
+                            <TextBlock x:Name="AppBGCustomizerNote" Text="{x:Bind helper:Locale.Lang._SettingsPage.AppBG_Note}" Visibility="Collapsed"
+            Width="368" TextWrapping="Wrap"
+            HorizontalAlignment="Left"
+            Margin="0,16,0,0" FontSize="12"
+            FontWeight="Bold" Foreground="{ThemeResource AccentColor}"/>
+                        </StackPanel>
+                        <TextBlock Text="{x:Bind helper:Locale.Lang._SettingsPage.AppWindowSize}" Style="{ThemeResource SubtitleTextBlockStyle}" Margin="0,10,0,4"/>
+                        <StackPanel Margin="8,-8,0,8">
                             <RadioButtons x:Name="WindowSizeSelection" SelectedIndex="{x:Bind SelectedWindowSizeProfile, Mode=TwoWay}" MaxColumns="2">
                                 <StackPanel Orientation="Horizontal" Margin="0,-1,0,0">
                                     <TextBlock FontFamily="{ThemeResource FontAwesomeSolid}" Text="&#xf065;" FontSize="22"/>
@@ -50,8 +62,11 @@
                                 </StackPanel>
                             </RadioButtons>
                         </StackPanel>
-                        <TextBlock Text="{x:Bind helper:Locale.Lang._SettingsPage.AppCDNRepository}" Style="{ThemeResource SubtitleTextBlockStyle}" Margin="0,16,0,16"/>
-                        <StackPanel Margin="0,-8,0,16">
+                        <TextBlock Text="{x:Bind helper:Locale.Lang._SettingsPage.DiscordRPC}" Style="{ThemeResource SubtitleTextBlockStyle}" Margin="0,8,0,8"/>
+                        <ToggleSwitch x:Name="ToggleDiscordRPC" Header="{x:Bind helper:Locale.Lang._SettingsPage.DiscordRPC_Toggle}" OffContent="{x:Bind helper:Locale.Lang._Misc.Disabled}" OnContent="{x:Bind helper:Locale.Lang._Misc.Enabled}" Margin="8,0,0,4" IsOn="{x:Bind IsDiscordRPCEnabled, Mode=TwoWay}"/>
+                        <ToggleSwitch x:Name="ToggleDiscordGameStatus" Header="{x:Bind helper:Locale.Lang._SettingsPage.DiscordRPC_GameStatusToggle}" OffContent="{x:Bind helper:Locale.Lang._Misc.Disabled}" OnContent="{x:Bind helper:Locale.Lang._Misc.Enabled}" Margin="8,0,0,4" IsEnabled="False" IsOn="{x:Bind IsDiscordGameStatusEnabled, Mode=TwoWay}" Visibility="Collapsed"/>
+                        <TextBlock Text="{x:Bind helper:Locale.Lang._SettingsPage.AppCDNRepository}" Style="{ThemeResource SubtitleTextBlockStyle}" Margin="0,8,0,4"/>
+                        <StackPanel Margin="8,-8,0,16">
                             <RadioButtons x:Name="AppCDNSelection" SelectedIndex="{x:Bind SelectedCDN, Mode=TwoWay}" MaxColumns="3" ItemsSource="{x:Bind innerConfig:LauncherConfig.CDNList}">
                                 <RadioButtons.ItemTemplate>
                                     <DataTemplate x:DataType="innerConfig:CDNURLProperty">
@@ -65,26 +80,8 @@
                                 </RadioButtons.ItemTemplate>
                             </RadioButtons>
                         </StackPanel>
-                        <TextBlock Text="{x:Bind helper:Locale.Lang._SettingsPage.AppBG}" Style="{ThemeResource SubtitleTextBlockStyle}" Margin="0,16,0,16"/>
-                        <StackPanel Margin="0,0,0,16" HorizontalAlignment="Left">
-                            <CheckBox x:Name="AppBGMode" Content="{x:Bind helper:Locale.Lang._SettingsPage.AppBG_Checkbox}" IsChecked="{x:Bind IsBGCustom, Mode=TwoWay}"/>
-                            <StackPanel Orientation="Horizontal" Margin="-2,8,0,0">
-                                <Button x:Name="BGSelector" IsEnabled="False" Margin="-32,0,0,0" CornerRadius="0,16,16,0" Click="SelectBackgroundImg" Style="{ThemeResource AccentButtonStyle}">
-                                    <StackPanel Orientation="Horizontal" Margin="32,0,0,0">
-                                        <TextBlock FontFamily="{ThemeResource FontAwesome}" Text="&#xF03E;" FontSize="22"/>
-                                        <TextBlock Text="{x:Bind helper:Locale.Lang._Misc.Select}" Margin="8,0,0,0" FontWeight="Medium" VerticalAlignment="Center"/>
-                                    </StackPanel>
-                                </Button>
-                                <TextBlock x:Name="BGPathDisplay" Text="" VerticalAlignment="Center" Width="384" Margin="12,0,0,0" TextTrimming="CharacterEllipsis"/>
-                            </StackPanel>
-                            <TextBlock Text="{x:Bind helper:Locale.Lang._SettingsPage.AppBG_Note}"
-                                   Width="368" TextWrapping="Wrap"
-                                   HorizontalAlignment="Left"
-                                   Margin="0,16,0,0" FontSize="12"
-                                   FontWeight="Bold" Foreground="{ThemeResource AccentColor}"/>
-                        </StackPanel>
                         <StackPanel Orientation="Horizontal">
-                            <TextBlock Text="{x:Bind helper:Locale.Lang._SettingsPage.AppThreads}" Style="{ThemeResource SubtitleTextBlockStyle}" Margin="0,16,0,16"/>
+                            <TextBlock Text="{x:Bind helper:Locale.Lang._SettingsPage.AppThreads}" Style="{ThemeResource SubtitleTextBlockStyle}" Margin="0,0,0,8"/>
                             <Button Margin="16,0">
                                 <Button.Content>
                                     <FontIcon FontFamily="{ThemeResource FontAwesome}" Glyph="&#x3f;" FontSize="12"/>
@@ -118,76 +115,16 @@
                                 </Button.Flyout>
                             </Button>
                         </StackPanel>
-                        <StackPanel Margin="0,0,0,16" Orientation="Horizontal" HorizontalAlignment="Left">
+                        <StackPanel Margin="8,0,0,8" Orientation="Horizontal" HorizontalAlignment="Left">
                             <NumberBox x:Name="DownloadThreadsNumBox" Header="{x:Bind helper:Locale.Lang._SettingsPage.AppThreads_Download}" Width="128" Value="{x:Bind CurrentAppThreadDownloadValue, Mode=TwoWay}" Minimum="2" Maximum="8" SpinButtonPlacementMode="Compact"/>
                             <NumberBox x:Name="ExtractionThreadsNumBox" Header="{x:Bind helper:Locale.Lang._SettingsPage.AppThreads_Extract}" Margin="16,0,0,0" Value="{x:Bind CurrentAppThreadExtractValue, Mode=TwoWay}" Minimum="0" Maximum="128" Width="128" SpinButtonPlacementMode="Compact"/>
                         </StackPanel>
-                        <TextBlock Text="{x:Bind helper:Locale.Lang._SettingsPage.DiscordRPC}" Style="{ThemeResource SubtitleTextBlockStyle}" Margin="0,16,0,16"/>
-                        <ToggleSwitch x:Name="ToggleDiscordRPC" Header="{x:Bind helper:Locale.Lang._SettingsPage.DiscordRPC_Toggle}" OffContent="{x:Bind helper:Locale.Lang._Misc.Disabled}" OnContent="{x:Bind helper:Locale.Lang._Misc.Enabled}" Margin="0,4" IsOn="{x:Bind IsDiscordRPCEnabled, Mode=TwoWay}"/>
-                        <ToggleSwitch x:Name="ToggleDiscordGameStatus" Header="{x:Bind helper:Locale.Lang._SettingsPage.DiscordRPC_GameStatusToggle}" OffContent="{x:Bind helper:Locale.Lang._Misc.Disabled}" OnContent="{x:Bind helper:Locale.Lang._Misc.Enabled}" Margin="0,4" IsEnabled="False" IsOn="{x:Bind IsDiscordGameStatusEnabled, Mode=TwoWay}" />
-                        <TextBlock Text="{x:Bind helper:Locale.Lang._SettingsPage.Update}" Style="{ThemeResource SubtitleTextBlockStyle}" Margin="0,16,0,16"/>
-                        <StackPanel Orientation="Vertical" Margin="0,0,0,16">
-                            <StackPanel Orientation="Horizontal">
-                                <TextBlock VerticalAlignment="Center" Margin="0,0,0,16">
-                                <Run Text="{x:Bind helper:Locale.Lang._SettingsPage.Update_CurVer}"/>
-                                <Run x:Name="CurrentVersion" Text="0.0.0.0" Foreground="{ThemeResource AccentColor}" FontWeight="Bold"/>
-                                </TextBlock>
-                            </StackPanel>
-                            <StackPanel Orientation="Horizontal">
-                                <Button x:Name="CheckUpdateBtn" Margin="-32,0,0,0" Height="38" CornerRadius="0,17,17,0" Click="CheckUpdate" Style="{ThemeResource AccentButtonStyle}">
-                                    <StackPanel Orientation="Horizontal" Margin="32,0,0,0">
-                                        <TextBlock FontFamily="{ThemeResource FontAwesomeSolid}" Text="&#xf105;" FontSize="22"/>
-                                        <TextBlock Text="{x:Bind helper:Locale.Lang._SettingsPage.Update_CheckBtn}" Margin="8,-2,0,0" FontWeight="Medium" VerticalAlignment="Center"/>
-                                    </StackPanel>
-                                </Button>
-                                <StackPanel x:Name="UpdateLoadingStatus" Visibility="Collapsed" Orientation="Horizontal" Margin="16,0,0,0" VerticalAlignment="Center">
-                                    <ProgressRing Width="20" Height="20" IsIndeterminate="True"/>
-                                </StackPanel>
-                                <StackPanel x:Name="UpdateAvailableStatus" Visibility="Collapsed" Orientation="Horizontal" Margin="16,-3,0,0" VerticalAlignment="Center">
-                                    <TextBlock Text="😆" FontSize="20"/>
-                                    <TextBlock Margin="8,0,0,0" VerticalAlignment="Center">
-                                    <Run Text="{x:Bind helper:Locale.Lang._SettingsPage.Update_NewVer1}"/>
-                                    <Run x:Name="UpdateAvailableLabel" Text="0.0.0.0" Foreground="{ThemeResource AccentColor}" FontWeight="Bold"/>
-                                    <Run Text="{x:Bind helper:Locale.Lang._SettingsPage.Update_NewVer2}"/>
-                                    </TextBlock>
-                                </StackPanel>
-                                <StackPanel x:Name="UpToDateStatus" Visibility="Collapsed" Orientation="Horizontal" Margin="16,-3,0,0" VerticalAlignment="Center">
-                                    <TextBlock Text="✅" FontSize="20"/>
-                                    <TextBlock Text="{x:Bind helper:Locale.Lang._SettingsPage.Update_LatestVer}" Margin="8,0,0,0" VerticalAlignment="Center"/>
-                                </StackPanel>
-                            </StackPanel>
-                            <Button x:Name="ForceUpdateBtn" Margin="-32,16,0,0" Height="38" CornerRadius="0,17,17,0" Click="ForceUpdate" Style="{ThemeResource AccentButtonStyle}">
-                                <StackPanel Orientation="Horizontal" Margin="32,0,0,0">
-                                    <TextBlock FontFamily="{ThemeResource FontAwesomeSolid}" Text="&#xf101;" FontSize="22"/>
-                                    <TextBlock Text="{x:Bind helper:Locale.Lang._SettingsPage.Update_ForceBtn}" Margin="8,-2,0,0" FontWeight="Medium" VerticalAlignment="Center"/>
-                                </StackPanel>
-                            </Button>
-                            <Button x:Name="ChangeReleaseBtn" Margin="-32,16,0,0" Height="38" CornerRadius="0,17,17,0" Click="ChangeRelease" Style="{ThemeResource AccentButtonStyle}">
-                                <StackPanel Orientation="Horizontal" Margin="32,0,0,0">
-                                    <TextBlock FontFamily="{ThemeResource FontAwesomeSolid}" Text="&#xf0ec;" FontSize="22"/>
-                                    <TextBlock x:Name="ChangeReleaseBtnText" Margin="8,-2,0,0" FontWeight="Medium" VerticalAlignment="Center"/>
-                                </StackPanel>
-                            </Button>
-                        </StackPanel>
-                        <TextBlock Text="{x:Bind helper:Locale.Lang._SettingsPage.AppFiles}" Style="{ThemeResource SubtitleTextBlockStyle}" Margin="0,16,0,16"/>
-                        <StackPanel Orientation="Horizontal"  Margin="0,0,0,16">
-                            <Button CornerRadius="15" Style="{ThemeResource AccentButtonStyle}" Margin="0,0,16,0" Click="OpenAppDataFolder">
-                                <StackPanel Orientation="Horizontal">
-                                    <TextBlock Margin="8,0" Text="{x:Bind helper:Locale.Lang._SettingsPage.AppFiles_OpenDataFolderBtn}" FontWeight="Medium"/>
-                                </StackPanel>
-                            </Button>
-                            <Button CornerRadius="15" Style="{ThemeResource AccentButtonStyle}" Click="RelocateFolder">
-                                <TextBlock Margin="8,0" Text="{x:Bind helper:Locale.Lang._SettingsPage.AppFiles_RelocateDataFolderBtn}" FontWeight="Medium"/>
-                            </Button>
-                        </StackPanel>
-                        <StackPanel Orientation="Horizontal" Margin="0,0,0,16">
-                            <Button CornerRadius="15" Style="{ThemeResource AccentButtonStyle}" Margin="0,0,16,0" Click="ClearLogsFolder">
-                                <TextBlock Margin="8,0" Text="{x:Bind helper:Locale.Lang._SettingsPage.AppFiles_ClearLogBtn}" FontWeight="Medium"/>
-                            </Button>
-                            <Button CornerRadius="15" Style="{ThemeResource AccentButtonStyle}" Click="ClearImgFolder">
-                                <TextBlock Margin="8,0" Text="{x:Bind helper:Locale.Lang._SettingsPage.AppFiles_ClearImgCachesBtn}" FontWeight="Medium"/>
-                            </Button>
-                        </StackPanel>
+                        <TextBlock Text="{x:Bind helper:Locale.Lang._SettingsPage.Debug}" Style="{ThemeResource SubtitleTextBlockStyle}" Margin="0,12,0,8"/>
+                        <ToggleSwitch Header="{x:Bind helper:Locale.Lang._SettingsPage.Debug_Console}" OffContent="{x:Bind helper:Locale.Lang._Misc.Disabled}" OnContent="{x:Bind helper:Locale.Lang._Misc.Enabled}" IsOn="{x:Bind IsConsoleEnabled, Mode=TwoWay}" Margin="8,0"/>
+                        <ToggleSwitch x:Name="ToggleIncludeGameLogs" Header="{x:Bind helper:Locale.Lang._SettingsPage.Debug_IncludeGameLogs}" OffContent="{x:Bind helper:Locale.Lang._Misc.Disabled}" OnContent="{x:Bind helper:Locale.Lang._Misc.Enabled}" IsOn="{x:Bind IsIncludeGameLogs, Mode=TwoWay}" Margin="8,0" Visibility="Collapsed"/>
+                        <ToggleSwitch Header="{x:Bind helper:Locale.Lang._SettingsPage.Debug_MultipleInstance}" OffContent="{x:Bind helper:Locale.Lang._Misc.Disabled}" OnContent="{x:Bind helper:Locale.Lang._Misc.Enabled}" IsOn="{x:Bind IsMultipleInstanceEnabled, Mode=TwoWay}" Margin="8,0"/>
+                        <ToggleSwitch Header="{x:Bind helper:Locale.Lang._SettingsPage.ChangeRegionWarning_Toggle}" OffContent="{x:Bind helper:Locale.Lang._Misc.Disabled}" OnContent="{x:Bind helper:Locale.Lang._Misc.Enabled}" IsOn="{x:Bind IsShowRegionChangeWarning, Mode=TwoWay}" Margin="8,0"/>
+                        <TextBlock x:Name="ChangeRegionToggleWarning" Visibility="Collapsed" Text="{x:Bind helper:Locale.Lang._SettingsPage.ChangeRegionWarning_Warning}" Margin="8,0,0,8" FontWeight="Bold" Foreground="{ThemeResource AccentColor}"/>
                     </StackPanel>
                 </StackPanel>
             </StackPanel>
@@ -195,7 +132,7 @@
                 <StackPanel>
                     <Image Source="ms-appx:///Assets/CollapseLauncherLogo.png" Width="192" HorizontalAlignment="Left"/>
                     <TextBlock Text="{x:Bind helper:Locale.Lang._SettingsPage.About}" Style="{ThemeResource SubtitleTextBlockStyle}" Margin="0,16,0,8"/>
-                    <Grid>
+                    <Grid Margin="8,0">
                         <StackPanel Grid.Column="1">
                             <StackPanel Orientation="Horizontal">
                                 <TextBlock Text="Collapse Launcher" Style="{ThemeResource BodyStrongTextBlockStyle}"/>
@@ -214,9 +151,12 @@
                             </StackPanel>
                         </StackPanel>
                     </Grid>
-                    <StackPanel Margin="0,8,0,0">
+                    <StackPanel Margin="8,8,0,0">
                         <TextBlock Style="{ThemeResource BodyStrongTextBlockStyle}" Margin="0,8,0,4" HorizontalAlignment="Left">
                             <Hyperlink NavigateUri="https://github.com/neon-nyan/CollapseLauncher/issues" UnderlineStyle="None"><Run Text="{x:Bind helper:Locale.Lang._SettingsPage.ReportIssueBtn}"/></Hyperlink>
+                        </TextBlock>
+                        <TextBlock Style="{ThemeResource BodyStrongTextBlockStyle}" Margin="0,4,0,4" HorizontalAlignment="Left">
+                            <Hyperlink NavigateUri="https://github.com/neon-nyan/Collapse/graphs/contributors" UnderlineStyle="None"><Run Text="{x:Bind helper:Locale.Lang._SettingsPage.ContributorListBtn}"/></Hyperlink>
                         </TextBlock>
                         <TextBlock Style="{ThemeResource BodyStrongTextBlockStyle}" Margin="0,4,0,8" HorizontalAlignment="Left">
                             <Hyperlink NavigateUri="https://github.com/neon-nyan/CollapseLauncher/pulls" UnderlineStyle="None"><Run Text="{x:Bind helper:Locale.Lang._SettingsPage.ContributePRBtn}"/></Hyperlink>
@@ -225,7 +165,7 @@
                 </StackPanel>
                 <StackPanel Margin="0,8">
                     <TextBlock Text="{x:Bind helper:Locale.Lang._SettingsPage.Disclaimer}" Style="{ThemeResource SubtitleTextBlockStyle}" Margin="0,0,0,8"/>
-                    <TextBlock TextWrapping="Wrap" Style="{ThemeResource BodyTextBlockStyle}">
+                    <TextBlock TextWrapping="Wrap" Style="{ThemeResource BodyTextBlockStyle}" Margin="8,0">
                             <Run Text="{x:Bind helper:Locale.Lang._SettingsPage.Disclaimer1}"/>
                             <Hyperlink NavigateUri="https://www.mihoyo.com" UnderlineStyle="None" FontWeight="Bold"><Run Text="miHoYo"/></Hyperlink>
                             <Run Text="/"/>
@@ -267,25 +207,25 @@
                         <Run Text="~neon-nyan"/>
                     </TextBlock>
                 </StackPanel>
-                <Button CornerRadius="25" Style="{ThemeResource AccentButtonStyle}" Height="50" Margin="0,8,0,8" Tag="https://discord.gg/vJd2exaS7j" Click="ClickButtonLinkFromTag">
+                <Button Style="{ThemeResource AccentButtonStyle}" Height="40" Width="300" CornerRadius="20" Margin="0,8,0,8" Tag="https://discord.gg/vJd2exaS7j" Click="ClickButtonLinkFromTag">
                     <StackPanel Orientation="Horizontal" VerticalAlignment="Stretch" HorizontalAlignment="Left" Margin="4,0,12,0">
                         <TextBlock FontFamily="{ThemeResource FontAwesomeBrand}" Text="&#xF392;" FontSize="24" PointerPressed="ClickTextLinkFromTag" Margin="0,-1,12,0"
                                    HorizontalAlignment="Left" VerticalAlignment="Center"/>
-                        <TextBlock Text="{x:Bind helper:Locale.Lang._SettingsPage.DiscordBtn3}" FontSize="14" VerticalAlignment="Center" FontWeight="Bold"/>
+                        <TextBlock Text="{x:Bind helper:Locale.Lang._SettingsPage.DiscordBtn3}" FontSize="14" VerticalAlignment="Center" FontWeight="Medium"/>
                     </StackPanel>
                 </Button>
-                <Button CornerRadius="25" Style="{ThemeResource AccentButtonStyle}" Height="50" Margin="0,8,0,8" Tag="https://discord.gg/NAYQ8TT2Ge" Click="ClickButtonLinkFromTag">
+                <Button Style="{ThemeResource AccentButtonStyle}" Height="40" Width="300" CornerRadius="20" Margin="0,8,0,8" Tag="https://discord.gg/NAYQ8TT2Ge" Click="ClickButtonLinkFromTag">
                     <StackPanel Orientation="Horizontal" VerticalAlignment="Stretch" HorizontalAlignment="Left" Margin="4,0,12,0">
                         <TextBlock FontFamily="{ThemeResource FontAwesomeBrand}" Text="&#xF392;" FontSize="24" PointerPressed="ClickTextLinkFromTag" Margin="0,-1,12,0"
                                    HorizontalAlignment="Left" VerticalAlignment="Center"/>
-                        <TextBlock Text="{x:Bind helper:Locale.Lang._SettingsPage.DiscordBtn1}" FontSize="14" VerticalAlignment="Center" FontWeight="Bold"/>
+                        <TextBlock Text="{x:Bind helper:Locale.Lang._SettingsPage.DiscordBtn1}" FontSize="14" VerticalAlignment="Center" FontWeight="Medium"/>
                     </StackPanel>
                 </Button>
-                <Button CornerRadius="25" Style="{ThemeResource AccentButtonStyle}" Height="50" Margin="0,8,0,8" Tag="https://discord.gg/hi3" Click="ClickButtonLinkFromTag">
+                <Button Style="{ThemeResource AccentButtonStyle}" Height="40" Width="300" CornerRadius="20" Margin="0,8,0,8" Tag="https://discord.gg/hi3" Click="ClickButtonLinkFromTag">
                     <StackPanel Orientation="Horizontal" VerticalAlignment="Stretch" HorizontalAlignment="Left" Margin="4,0,12,0">
                         <TextBlock FontFamily="{ThemeResource FontAwesomeBrand}" Text="&#xF392;" FontSize="24" PointerPressed="ClickTextLinkFromTag" Margin="0,-1,12,0"
                                    HorizontalAlignment="Left" VerticalAlignment="Center"/>
-                        <TextBlock Text="{x:Bind helper:Locale.Lang._SettingsPage.DiscordBtn2}" FontSize="14" VerticalAlignment="Center" FontWeight="Bold"/>
+                        <TextBlock Text="{x:Bind helper:Locale.Lang._SettingsPage.DiscordBtn2}" FontSize="14" VerticalAlignment="Center" FontWeight="Medium"/>
                     </StackPanel>
                 </Button>
                 <StackPanel Orientation="Horizontal" Margin="0,16,0,0" HorizontalAlignment="Left">
@@ -301,6 +241,63 @@
                                Tag="https://instagram.com/neonnyann/"/>
                     <TextBlock FontFamily="{ThemeResource FontAwesomeBrand}" Foreground="{ThemeResource AccentColor}" Text="&#xE499;" FontSize="24" PointerPressed="Egg" Margin="6,0,6,0"/>
                 </StackPanel>
+                <TextBlock Text="{x:Bind helper:Locale.Lang._SettingsPage.Update}" Style="{ThemeResource SubtitleTextBlockStyle}" Margin="0,20,0,8"/>
+                <StackPanel Orientation="Vertical" Margin="0,0,0,8">
+                    <StackPanel Orientation="Horizontal">
+                        <TextBlock VerticalAlignment="Center" Margin="8,0,0,10">
+                            <Run Text="{x:Bind helper:Locale.Lang._SettingsPage.Update_CurVer}"/>
+                            <Run x:Name="CurrentVersion" Text="0.0.0.0" Foreground="{ThemeResource AccentColor}" FontWeight="Bold"/>
+                        </TextBlock>
+                    </StackPanel>
+                    <Button x:Name="CheckUpdateBtn" Margin="0,0,0,0" Height="40" Width="300" CornerRadius="20" Click="CheckUpdate" Style="{ThemeResource AccentButtonStyle}">
+                        <StackPanel Orientation="Horizontal" Margin="0,0,0,0">
+                            <TextBlock FontFamily="{ThemeResource FontAwesomeSolid}" Text="&#xf105;" FontSize="22"/>
+                            <TextBlock Text="{x:Bind helper:Locale.Lang._SettingsPage.Update_CheckBtn}" Margin="8,-2,0,0" FontWeight="Medium" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </Button>
+                    <StackPanel x:Name="UpdateLoadingStatus" Visibility="Collapsed" Orientation="Horizontal" Margin="16,4,0,0" VerticalAlignment="Center">
+                        <ProgressRing Width="20" Height="20" IsIndeterminate="True"/>
+                    </StackPanel>
+                    <StackPanel x:Name="UpdateAvailableStatus" Visibility="Collapsed" Orientation="Horizontal" Margin="16,4,0,0" VerticalAlignment="Center">
+                        <TextBlock Text="😆" FontSize="20"/>
+                        <TextBlock Margin="8,4,0,0" VerticalAlignment="Center">
+            <Run Text="{x:Bind helper:Locale.Lang._SettingsPage.Update_NewVer1}"/>
+            <Run x:Name="UpdateAvailableLabel" Text="0.0.0.0" Foreground="{ThemeResource AccentColor}" FontWeight="Bold"/>
+            <Run Text="{x:Bind helper:Locale.Lang._SettingsPage.Update_NewVer2}"/>
+                        </TextBlock>
+                    </StackPanel>
+                    <StackPanel x:Name="UpToDateStatus" Visibility="Collapsed" Orientation="Horizontal" Margin="16,2,0,0" VerticalAlignment="Center">
+                        <TextBlock Text="✅" FontSize="20"/>
+                        <TextBlock Text="{x:Bind helper:Locale.Lang._SettingsPage.Update_LatestVer}" Margin="8,0,0,0" VerticalAlignment="Center"/>
+                    </StackPanel>
+                    <Button x:Name="ForceUpdateBtn" Margin="0,16,0,0" Height="40" Width="300" CornerRadius="20" Click="ForceUpdate" Style="{ThemeResource AccentButtonStyle}">
+                        <StackPanel Orientation="Horizontal" Margin="0,0,0,0">
+                            <TextBlock FontFamily="{ThemeResource FontAwesomeSolid}" Text="&#xf101;" FontSize="22"/>
+                            <TextBlock Text="{x:Bind helper:Locale.Lang._SettingsPage.Update_ForceBtn}" Margin="8,-2,0,0" FontWeight="Medium" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </Button>
+                    <Button x:Name="ChangeReleaseBtn" Margin="0,16,0,0" Height="40" Width="300" CornerRadius="20" Click="ChangeRelease" Style="{ThemeResource AccentButtonStyle}">
+                        <StackPanel Orientation="Horizontal" Margin="0,0,0,0">
+                            <TextBlock FontFamily="{ThemeResource FontAwesomeSolid}" Text="&#xf0ec;" FontSize="22"/>
+                            <TextBlock x:Name="ChangeReleaseBtnText" Margin="8,-2,0,0" FontWeight="Medium" VerticalAlignment="Center"/>
+                        </StackPanel>
+                    </Button>
+                </StackPanel>
+                <TextBlock Text="{x:Bind helper:Locale.Lang._SettingsPage.AppFiles}" Style="{ThemeResource SubtitleTextBlockStyle}" Margin="0,16,0,16"/>
+                <Button Margin="8,0,0,8" Width="292" CornerRadius="15" Style="{ThemeResource AccentButtonStyle}" Click="RelocateFolder">
+                    <TextBlock Margin="8,0" Text="{x:Bind helper:Locale.Lang._SettingsPage.AppFiles_RelocateDataFolderBtn}" FontWeight="Medium"/>
+                </Button>
+                <Button Margin="8,0,0,8" Width="292" CornerRadius="15" Style="{ThemeResource AccentButtonStyle}" Click="OpenAppDataFolder">
+                    <StackPanel Orientation="Horizontal">
+                        <TextBlock Margin="8,0" Text="{x:Bind helper:Locale.Lang._SettingsPage.AppFiles_OpenDataFolderBtn}" FontWeight="Medium"/>
+                    </StackPanel>
+                </Button>
+                <Button Margin="8,0,0,8" Width="292" CornerRadius="15" Style="{ThemeResource AccentButtonStyle}" Click="ClearImgFolder">
+                    <TextBlock Margin="8,0" Text="{x:Bind helper:Locale.Lang._SettingsPage.AppFiles_ClearImgCachesBtn}" FontWeight="Medium"/>
+                </Button>
+                <Button Margin="8,0,0,8" Width="292" CornerRadius="15" Style="{ThemeResource AccentButtonStyle}" Click="ClearLogsFolder">
+                    <TextBlock Margin="8,0" Text="{x:Bind helper:Locale.Lang._SettingsPage.AppFiles_ClearLogBtn}" FontWeight="Medium"/>
+                </Button>
             </StackPanel>
         </Grid>
     </ScrollViewer>

--- a/CollapseLauncher/XAMLs/MainApp/Pages/SettingsPage.xaml.cs
+++ b/CollapseLauncher/XAMLs/MainApp/Pages/SettingsPage.xaml.cs
@@ -242,6 +242,17 @@ namespace CollapseLauncher.Pages
                 else
                     BGPathDisplay.Text = Lang._Misc.NotSelected;
 
+                if (IsEnabled)
+                {
+                    AppBGCustomizer.Visibility = Visibility.Visible;
+                    AppBGCustomizerNote.Visibility = Visibility.Visible;
+                }
+                else
+                {
+                    AppBGCustomizer.Visibility = Visibility.Collapsed;
+                    AppBGCustomizerNote.Visibility = Visibility.Collapsed;
+                }
+
                 BGSelector.IsEnabled = IsEnabled;
                 return IsEnabled;
             }
@@ -253,6 +264,8 @@ namespace CollapseLauncher.Pages
                     BGPathDisplay.Text = Lang._Misc.NotSelected;
                     regionBackgroundProp.imgLocalPath = GetAppConfigValue("CurrentBackground").ToString();
                     BackgroundImgChanger.ChangeBackground(regionBackgroundProp.imgLocalPath, false);
+                    AppBGCustomizer.Visibility = Visibility.Collapsed;
+                    AppBGCustomizerNote.Visibility = Visibility.Collapsed;
                 }
                 else
                 {
@@ -274,6 +287,8 @@ namespace CollapseLauncher.Pages
                     }
                     BGPathDisplay.Text = regionBackgroundProp.imgLocalPath;
                     BackgroundImgChanger.ChangeBackground(regionBackgroundProp.imgLocalPath);
+                    AppBGCustomizer.Visibility = Visibility.Visible;
+                    AppBGCustomizerNote.Visibility = Visibility.Visible;
                 }
                 BGSelector.IsEnabled = value;
             }
@@ -281,15 +296,32 @@ namespace CollapseLauncher.Pages
 
         private bool IsConsoleEnabled
         {
-            get => GetAppConfigValue("EnableConsole").ToBool();
+            get
+            {
+                bool isEnabled = GetAppConfigValue("EnableConsole").ToBool();
+                if (isEnabled)
+                {
+                    ToggleIncludeGameLogs.Visibility = Visibility.Visible;
+                }
+                else
+                {
+                    ToggleIncludeGameLogs.Visibility = Visibility.Collapsed;
+                }
+                return isEnabled;
+            }
             set
             {
                 _log.Dispose();
                 if (value)
+                {
                     _log = new LoggerConsole(AppGameLogsFolder, Encoding.UTF8);
+                    ToggleIncludeGameLogs.Visibility = Visibility.Visible;
+                }
                 else
+                {
                     _log = new LoggerNull(AppGameLogsFolder, Encoding.UTF8);
-
+                    ToggleIncludeGameLogs.Visibility = Visibility.Collapsed;
+                }
                 SetAndSaveConfigValue("EnableConsole", value);
             }
         }
@@ -307,15 +339,28 @@ namespace CollapseLauncher.Pages
             {
                 bool IsEnabled = GetAppConfigValue("EnableDiscordRPC").ToBool();
                 ToggleDiscordGameStatus.IsEnabled = IsEnabled;
+                if (IsEnabled)
+                {
+                    ToggleDiscordGameStatus.Visibility = Visibility.Visible;
+                }
+                else
+                {
+                    ToggleDiscordGameStatus.Visibility = Visibility.Collapsed;
+                }
                 return IsEnabled;
             }
             set
             {
                 if (value)
+                {
                     AppDiscordPresence.SetupPresence();
+                    ToggleDiscordGameStatus.Visibility = Visibility.Visible;
+                }
                 else
+                {
                     AppDiscordPresence.DisablePresence();
-
+                    ToggleDiscordGameStatus.Visibility = Visibility.Collapsed;
+                }
                 SetAndSaveConfigValue("EnableDiscordRPC", value);
                 ToggleDiscordGameStatus.IsEnabled = value;
             }
@@ -440,6 +485,12 @@ namespace CollapseLauncher.Pages
                 SetAppConfigValue("CurrentCDN", value);
                 SaveAppConfig();
             }
+        }
+
+        private bool IsIncludeGameLogs
+        {
+            get => GetAppConfigValue("IncludeGameLogs").ToBool();
+            set => SetAndSaveConfigValue("IncludeGameLogs", value);
         }
 
         private bool IsShowRegionChangeWarning

--- a/CollapseLauncher/XAMLs/MainApp/Pages/StarRailGameSettingsPage.xaml.cs
+++ b/CollapseLauncher/XAMLs/MainApp/Pages/StarRailGameSettingsPage.xaml.cs
@@ -59,7 +59,7 @@ namespace CollapseLauncher.Pages
         {
             if (!IsNoReload)
             {
-                LogWriteLine("Module: RegistryMonitor has detected registry change outside of the launcher! Reloading the page...", LogType.Warning, true);
+                LogWriteLine("[HSR GSP Module] RegistryMonitor has detected registry change outside of the launcher! Reloading the page...", LogType.Warning, true);
                 DispatcherQueue.TryEnqueue(MainFrameChanger.ReloadCurrentMainFrame);
             }
         }

--- a/Hi3Helper.Core/Classes/DiscordPresence/DiscordPresenceManager.cs
+++ b/Hi3Helper.Core/Classes/DiscordPresence/DiscordPresenceManager.cs
@@ -218,12 +218,13 @@ namespace Hi3Helper.DiscordPresence
             _activity = new Activity
             {
                 Details = $"{activityName} {(!isGameStatusEnabled ? ConfigV2Store.CurrentConfigV2GameCategory : Lang._Misc.DiscordRP_Ad)}",
-                State = $"Server: {ConfigV2Store.CurrentConfigV2GameRegion}",
+                State = $"{Lang._Misc.DiscordRP_Region} {ConfigV2Store.CurrentConfigV2GameRegion}",
                 Assets = new ActivityAssets
                 {
                     LargeImage = $"game-{ConfigV2Store.CurrentConfigV2.GameType.ToString().ToLower()}-logo",
                     LargeText = $"{ConfigV2Store.CurrentConfigV2GameCategory} - {ConfigV2Store.CurrentConfigV2GameRegion}",
-                    SmallImage = $"launcher-logo"
+                    SmallImage = $"launcher-logo",
+                    SmallText = $"Collapse Launcher v{AppCurrentVersionString} {(IsPreview ? "Preview" : "Stable")}"
                 },
                 Timestamps = new ActivityTimestamps
                 {
@@ -247,21 +248,20 @@ namespace Hi3Helper.DiscordPresence
             _activity = new Activity
             {
                 Details = $"{activityName} {(!isGameStatusEnabled ? string.Empty : Lang._Misc.DiscordRP_Ad)}",
-                State = $"Server: {ConfigV2Store.CurrentConfigV2GameRegion}",
+                State = $"{Lang._Misc.DiscordRP_Region} {ConfigV2Store.CurrentConfigV2GameRegion}",
                 Assets = new ActivityAssets
                 {
                     LargeImage = $"game-{ConfigV2Store.CurrentConfigV2.GameType.ToString().ToLower()}-logo",
                     LargeText = $"{ConfigV2Store.CurrentConfigV2GameCategory}",
-                    SmallImage = $"launcher-logo"
+                    SmallImage = $"launcher-logo",
+                    SmallText = $"Collapse Launcher v{AppCurrentVersionString} {(IsPreview ? "Preview" : "Stable")}"
                 },
             };
         }
 
         private void UpdateActivity() => _activityManager?.UpdateActivity(_activity, (a) =>
         {
-#if DEBUG
             Logger.LogWriteLine($"Activity updated! => {_activity.Details} - {_activity.State}");
-#endif
         });
 
         private void UpdateCallbacksRoutine()

--- a/Hi3Helper.Core/Classes/Shared/Region/Config/LauncherConfig.cs
+++ b/Hi3Helper.Core/Classes/Shared/Region/Config/LauncherConfig.cs
@@ -184,8 +184,9 @@ namespace Hi3Helper.Shared.Region
             { "CurrentCDN", 0 },
             { "ShowRegionChangeWarning", true },
 #if !DISABLEDISCORD
-            { "EnableDiscordRPC", false }
+            { "EnableDiscordRPC", false },
 #endif
+            { "IncludeGameLogs", false }
         };
 
         public static void LoadGamePreset()

--- a/Hi3Helper.Core/Lang/Locale/LangMisc.cs
+++ b/Hi3Helper.Core/Lang/Locale/LangMisc.cs
@@ -91,6 +91,7 @@
                 public string DiscordRP_Idle { get; set; } = LangFallback?._Misc.DiscordRP_Idle;
                 public string DiscordRP_Default { get; set; } = LangFallback?._Misc.DiscordRP_Default;
                 public string DiscordRP_Ad { get; set; } = LangFallback?._Misc.DiscordRP_Ad;
+                public string DiscordRP_Region { get; set; } = LangFallback?._Misc.DiscordRP_Region;
             }
         }
         #endregion

--- a/Hi3Helper.Core/Lang/Locale/LangSettingsPage.cs
+++ b/Hi3Helper.Core/Lang/Locale/LangSettingsPage.cs
@@ -11,6 +11,7 @@
                 public string PageTitle { get; set; } = LangFallback?._SettingsPage.PageTitle;
                 public string Debug { get; set; } = LangFallback?._SettingsPage.Debug;
                 public string Debug_Console { get; set; } = LangFallback?._SettingsPage.Debug_Console;
+                public string Debug_IncludeGameLogs { get; set; } = LangFallback?._SettingsPage.Debug_IncludeGameLogs;
                 public string Debug_MultipleInstance { get; set; } = LangFallback?._SettingsPage.Debug_MultipleInstance;
                 public string ChangeRegionWarning_Toggle { get; set; } = LangFallback?._SettingsPage.ChangeRegionWarning_Toggle;
                 public string ChangeRegionWarning_Warning { get; set; } = LangFallback?._SettingsPage.ChangeRegionWarning_Warning;
@@ -55,6 +56,7 @@
                 public string AppFiles_ClearImgCachesBtn { get; set; } = LangFallback?._SettingsPage.AppFiles_ClearImgCachesBtn;
                 public string ReportIssueBtn { get; set; } = LangFallback?._SettingsPage.ReportIssueBtn;
                 public string ContributePRBtn { get; set; } = LangFallback?._SettingsPage.ContributePRBtn;
+                public string ContributorListBtn { get; set; } = LangFallback?._SettingsPage.ContributorListBtn;
                 public string About { get; set; } = LangFallback?._SettingsPage.About;
                 public string About_Copyright1 { get; set; } = LangFallback?._SettingsPage.About_Copyright1;
                 public string About_Copyright2 { get; set; } = LangFallback?._SettingsPage.About_Copyright2;

--- a/Hi3Helper.Core/Lang/en-us.json
+++ b/Hi3Helper.Core/Lang/en-us.json
@@ -305,6 +305,7 @@
 
     "Debug": "Debugging",
     "Debug_Console": "Show Console",
+    "Debug_IncludeGameLogs": "Save Game logs to Collapse's (might contain sensitive data)",
     "Debug_MultipleInstance": "Allow running multiple instances of Collapse",
 
     "ChangeRegionWarning_Toggle": "Show Region Change Warning",
@@ -360,6 +361,7 @@
 
     "ReportIssueBtn": "Report an Issue",
     "ContributePRBtn": "Contribute with a Pull Request",
+    "ContributorListBtn": "Open Source Contributors",
 
     "About": "About",
     "About_Copyright1": "© 2022-2023 Created by",
@@ -471,7 +473,8 @@
     "DiscordRP_AppSettings": "Changing App Settings",
     "DiscordRP_Idle": "Idle",
     "DiscordRP_Default": "No Activity",
-    "DiscordRP_Ad": "- On Collapse Launcher"
+    "DiscordRP_Ad": "- With Collapse Launcher",
+    "DiscordRP_Region": "Region:"
   },
 
   "_Dialogs": {


### PR DESCRIPTION
### App Settings page:
- Move around some parts to make settings page a little bit more compact
- Hide some settings that depends on other
- [New] Add toggle to include Game logs inside Collapse Logs
- [New] Add contributors list button

### Discord RPC:
- Localize `Region:` string
- [New] Add Collapse version and branch string to SmallText

### Collapse Core:
- Add debug lines for RegistryMonitor
- Change operator for Launcher Metadata Update to only update when local stamp is older than remote