### PR TITLE
Rewrite GameUninstall Method

### DIFF
--- a/CollapseLauncher/Classes/InstallManagement/BaseClass/InstallManagerBase.cs
+++ b/CollapseLauncher/Classes/InstallManagement/BaseClass/InstallManagerBase.cs
@@ -1400,11 +1400,7 @@ namespace CollapseLauncher.InstallManager.Base
         #endregion
 
         #region Virtual Methods - UninstallGame
-        protected virtual UninstallGameProperty AssignUninstallFolders()
-        {
-            LogWriteLine($"Cannot uninstall game: {_gameVersionManager.GamePreset.GameType}. Uninstall method is not yet implemented!", LogType.Error, true);
-            return new UninstallGameProperty();
-        }
+        protected virtual UninstallGameProperty AssignUninstallFolders() => throw new NotSupportedException($"Cannot uninstall game: {_gameVersionManager.GamePreset.GameType}. Uninstall method is not yet implemented!");
         #endregion
 
         #region Event Methods

--- a/CollapseLauncher/Classes/InstallManagement/BaseClass/InstallManagerBase.cs
+++ b/CollapseLauncher/Classes/InstallManagement/BaseClass/InstallManagerBase.cs
@@ -510,7 +510,7 @@ namespace CollapseLauncher.InstallManager.Base
                     foldersToKeepInDataFullPath[i] = Path.Combine(_DataFolderFullPath, UninstallProperty.foldersToKeepInData[i]);
                 }
 
-                LogWriteLine($"Uninstalling game: {_gameVersionManager.GameType} - region: {ConfigV2Store.CurrentConfigV2GameRegion}\r\n" +
+                LogWriteLine($"Uninstalling game: {_gameVersionManager.GameType} - region: {_gameVersionManager.GamePreset.ZoneName}\r\n" +
                     $"  GameFolder          : {GameFolder}\r\n" +
                     $"  gameDataFolderName  : {UninstallProperty.gameDataFolderName}\r\n" +
                     $"  foldersToDelete     : {string.Join(", ", UninstallProperty.foldersToDelete)}\r\n" +
@@ -622,7 +622,7 @@ namespace CollapseLauncher.InstallManager.Base
             }
             catch (Exception ex)
             {
-                LogWriteLine($"Failed while uninstalling game: {_gameVersionManager.GameType} - region: {ConfigV2Store.CurrentConfigV2GameRegion}\r\n{ex}", LogType.Error, true);
+                LogWriteLine($"Failed while uninstalling game: {_gameVersionManager.GameType} - region: {_gameVersionManager.GamePreset.ZoneName}\r\n{ex}", LogType.Error, true);
             }
             _gameVersionManager.Reinitialize();
             return true;

--- a/CollapseLauncher/Classes/InstallManagement/BaseClass/InstallManagerBase.cs
+++ b/CollapseLauncher/Classes/InstallManagement/BaseClass/InstallManagerBase.cs
@@ -575,7 +575,7 @@ namespace CollapseLauncher.InstallManager.Base
                 foreach (string fileNames in Directory.EnumerateFiles(GameFolder))
                 {
                     if (UninstallProperty.filesToDelete.Length != 0 && UninstallProperty.filesToDelete.Contains(Path.GetFileName(fileNames)) ||
-                        UninstallProperty.filesToDelete.Length != 0 && UninstallProperty.filesToDelete.Any(pattern => Regex.IsMatch(Path.GetFileName(fileNames), pattern)))
+                        UninstallProperty.filesToDelete.Length != 0 && UninstallProperty.filesToDelete.Any(pattern => Regex.IsMatch(Path.GetFileName(fileNames), pattern, RegexOptions.Compiled | RegexOptions.NonBacktracking)))
                     {
                         try
                         {

--- a/CollapseLauncher/Classes/InstallManagement/Genshin/GenshinInstall.cs
+++ b/CollapseLauncher/Classes/InstallManagement/Genshin/GenshinInstall.cs
@@ -284,14 +284,8 @@ namespace CollapseLauncher.InstallManager.Genshin
             {
                 "Global" => "GenshinImpact",
                 "Mainland China" => "YuanShen",
-                _ => string.Empty
+                _ => throw new NotSupportedException($"Unknown GI Game Region!: {_gameVersionManager.GamePreset.ZoneName}")
             };
-
-            if (string.IsNullOrEmpty(execName))
-            {
-                LogWriteLine($"Unknown GI Game Region!: {_gameVersionManager.GamePreset.ZoneName}", LogType.Error, true);
-                return new UninstallGameProperty();
-            }
 
             return new UninstallGameProperty()
             {

--- a/CollapseLauncher/Classes/InstallManagement/Genshin/GenshinInstall.cs
+++ b/CollapseLauncher/Classes/InstallManagement/Genshin/GenshinInstall.cs
@@ -2,6 +2,7 @@
 using CollapseLauncher.InstallManager.Base;
 using CollapseLauncher.Interfaces;
 using Hi3Helper;
+using Hi3Helper.Preset;
 using Hi3Helper.Shared.ClassStruct;
 using Microsoft.UI.Xaml;
 using System;
@@ -273,6 +274,32 @@ namespace CollapseLauncher.InstallManager.Genshin
 
                 LogWriteLine($"Adding additional {package.LanguageName} audio package: {package.Name} to the list (Hash: {package.HashString})", LogType.Default, true);
             }
+        }
+        #endregion
+
+        #region Override Methods - UninstallGame
+        protected override UninstallGameProperty AssignUninstallFolders()
+        {
+            string execName = _gameVersionManager.GamePreset.ZoneName switch
+            {
+                "Global" => "GenshinImpact",
+                "Mainland China" => "YuanShen",
+                _ => string.Empty
+            };
+
+            if (string.IsNullOrEmpty(execName))
+            {
+                LogWriteLine($"Unknown GI Game Region!: {_gameVersionManager.GamePreset.ZoneName}", LogType.Error, true);
+                return new UninstallGameProperty();
+            }
+
+            return new UninstallGameProperty()
+            {
+                gameDataFolderName = $"{execName}_Data",
+                foldersToDelete = new string[] { $"{execName}_Data" },
+                filesToDelete = new string[] { "HoYoKProtect.sys", "pkg_version", $"{execName}.exe", "UnityPlayer.dll", "config.ini", "^mhyp.*", "^Audio.*" },
+                foldersToKeepInData = new string[] { "ScreenShot" }
+            };
         }
         #endregion
     }

--- a/CollapseLauncher/Classes/InstallManagement/Honkai/HonkaiInstall.cs
+++ b/CollapseLauncher/Classes/InstallManagement/Honkai/HonkaiInstall.cs
@@ -351,5 +351,15 @@ namespace CollapseLauncher.InstallManager.Honkai
             return null;
         }
         #endregion
+
+        #region Override Methods - UninstallGame
+        protected override UninstallGameProperty AssignUninstallFolders() => new UninstallGameProperty()
+        {
+            gameDataFolderName = "BH3_Data",
+            foldersToDelete = new string[] { "BH3_Data", "AntiCheatExpert" },
+            filesToDelete = new string[] { "ACE-BASE.sys", "bugtrace.dll", "pkg_version", "UnityPlayer.dll", "config.ini" },
+            foldersToKeepInData = null
+        };
+        #endregion
     }
 }

--- a/CollapseLauncher/Classes/InstallManagement/StarRail/StarRailInstall.cs
+++ b/CollapseLauncher/Classes/InstallManagement/StarRail/StarRailInstall.cs
@@ -72,5 +72,15 @@ namespace CollapseLauncher.InstallManager.StarRail
             };
         }
         #endregion
+
+        #region Override Methods - UninstallGame
+        protected override UninstallGameProperty AssignUninstallFolders() => new UninstallGameProperty()
+        {
+            gameDataFolderName = "StarRail_Data",
+            foldersToDelete = new string[] { "AntiCheatExpert" },
+            filesToDelete = new string[] { "ACE-BASE.sys", "GameAssembly.dll", "pkg_version", "config.ini", "^StarRail.*", "^Unity.*" },
+            foldersToKeepInData = new string[] { "ScreenShots" }
+        };
+        #endregion
     }
 }


### PR DESCRIPTION
making the entire function from the older try of this method into one beeg method.

Old reference: https://github.com/bagusnl/Collapse/blob/8296c077a1c7ea4730f38a3b657cb39cfec7a6e0/CollapseLauncher/Classes/InstallManagement/BaseClass/InstallManagerBase.cs#L398-L726

With the help of @Arikatsu, @muscularcandy67, and @Cryotechnic 

Resolve #141 