### PR TITLE
Genshin Game Settings update

### DIFF
--- a/CollapseLauncher/Classes/GameManagement/GameSettings/Genshin/RegistryClass/Enums/Enums.cs
+++ b/CollapseLauncher/Classes/GameManagement/GameSettings/Genshin/RegistryClass/Enums/Enums.cs
@@ -119,5 +119,13 @@
         x8 = 4,
         x16 = 5
     }
+
+    enum GlobalIlluminationOption
+    {
+        Off = 1,
+        Medium = 2,
+        High = 3,
+        Extreme = 4
+    }
 }
 

--- a/CollapseLauncher/Classes/GameManagement/GameSettings/Genshin/RegistryClass/GeneralData.cs
+++ b/CollapseLauncher/Classes/GameManagement/GameSettings/Genshin/RegistryClass/GeneralData.cs
@@ -247,7 +247,7 @@ namespace CollapseLauncher.GameSettings.Genshin
         public bool gyroHorReverse { get; set; } = false;
         public bool gyroVerReverse { get; set; } = false;
         public int gyroRotateType { get; set; } = 0;
-        public bool gyroExcludeRightStickVerInput = false;
+        public bool gyroExcludeRightStickVerInput { get; set; } = false;
 
         //unsure what these does, probably HDR stuff? doesn't have HDR monitor to test...
         public bool firstHDRSetting { get; set; } = true;

--- a/CollapseLauncher/Classes/GameManagement/GameSettings/Genshin/RegistryClass/GeneralData.cs
+++ b/CollapseLauncher/Classes/GameManagement/GameSettings/Genshin/RegistryClass/GeneralData.cs
@@ -226,7 +226,7 @@ namespace CollapseLauncher.GameSettings.Genshin
 
 
         /// <summary>
-        /// This holds said override for those controllers.
+        /// This holds controller mapping override for controller ID in _overrideControllerMapKeyList.
         /// </summary>
         // Temporary for fallback before the implementation is made
         public List<string> _overrideControllerMapValueList { get; set; }
@@ -282,12 +282,6 @@ namespace CollapseLauncher.GameSettings.Genshin
 
         #region Methods
 #nullable enable
-#if DEBUG
-        // Set this to true if you want to dump the entire JSON of Genshin Settings to console
-        // Warning: Resource intensive!
-        private static bool DumpJSON = false;
-#endif
-
         public static GeneralData Load()
         {
             try
@@ -298,21 +292,24 @@ namespace CollapseLauncher.GameSettings.Genshin
                 if (value != null)
                 {
                     ReadOnlySpan<byte> byteStr = (byte[])value;
-#if DEBUG
-                    if (DumpJSON)
-                    {
-                        LogWriteLine($"RAW Genshin Settings: {_ValueName}\r\n" +
-                            $"{Encoding.UTF8.GetString((byte[])value)}", LogType.Debug, true);
+#if DUMPGIJSON
+                    // Dump GeneralData as raw string
+                    LogWriteLine($"RAW Genshin Settings: {_ValueName}\r\n" +
+                        $"{Encoding.UTF8.GetString((byte[])value)}", LogType.Debug, true);
 
-                        JsonSerializerOptions options_debug = new JsonSerializerOptions()
-                        {
-                            TypeInfoResolver = GenshinSettingsJSONContext.Default,
-                            Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
-                            WriteIndented = true
-                        };
-                        LogWriteLine($"Deserialized Genshin Settings: {_ValueName}\r\n{JsonSerializer.Serialize(JsonSerializer.Deserialize<GeneralData>(Encoding.UTF8.GetString((byte[])value, 0, ((byte[])value).Length - 1), options_debug), options_debug)}", LogType.Debug, true);
-                    }
-                    else LogWriteLine($"Loaded Genshin Settings: {_ValueName}", LogType.Debug, true);
+                    // Dump GeneralData as indented JSON output using GeneralData properties
+                    JsonSerializerOptions options_debug = new JsonSerializerOptions()
+                    {
+                        TypeInfoResolver = GenshinSettingsJSONContext.Default,
+                        Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
+                        WriteIndented = true
+                    };
+                    LogWriteLine($"Deserialized Genshin Settings: {_ValueName}\r\n{JsonSerializer.Serialize(JsonSerializer.Deserialize<GeneralData>(Encoding.UTF8.GetString((byte[])value, 0, ((byte[])value).Length - 1), options_debug), options_debug)}", LogType.Debug, true);
+#endif
+#if DEBUG
+                    LogWriteLine($"Loaded Genshin Settings: {_ValueName}", LogType.Debug,true);
+#else
+                    LogWriteLine($"Loaded Genshin Settings", LogType.Default, true);
 #endif
                     JsonSerializerOptions options = new JsonSerializerOptions()
                     {
@@ -350,30 +347,29 @@ namespace CollapseLauncher.GameSettings.Genshin
                 byte[] dataByte = Encoding.UTF8.GetBytes(data);
 
                 RegistryRoot.SetValue(_ValueName, dataByte, RegistryValueKind.Binary);
-#if DEBUG
-                if (DumpJSON)
-                {
-                    JsonSerializerOptions options_debug = new JsonSerializerOptions()
+#if DUMPGIJSON
+                //Dump saved GeneralData JSON from Collapse as indented output
+                JsonSerializerOptions options_debug = new JsonSerializerOptions()
                     {
                         TypeInfoResolver = GenshinSettingsJSONContext.Default,
                         Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
                         WriteIndented = true
                     };
-                    LogWriteLine($"Saved Genshin Settings: {_ValueName}\r\n{JsonSerializer.Serialize(this, typeof(GeneralData), options_debug)}", LogType.Debug, true);
-                }
-                else
-                {
-                    LogWriteLine($"Saved Genshin Settings: {_ValueName}" +
-                        $"\r\n      Text Language        : {deviceLanguageType}" +
-                        $"\r\n      VO Language          : {deviceVoiceLanguageType}" +
-                        $"\r\n      Audio - Master Volume: {volumeGlobal}" +
-                        $"\r\n      Audio - Music Volume : {volumeMusic}" +
-                        $"\r\n      Audio - SFX Volume   : {volumeSFX}" +
-                        $"\r\n      Audio - Voice Volume : {volumeVoice}" +
-                        $"\r\n      Audio - Dynamic Range: {audioDynamicRange}" +
-                        $"\r\n      Audio - Surround     : {audioOutput}" +
-                        $"\r\n      Gamma                : {gammaValue}", LogType.Debug);
-                }
+                LogWriteLine($"Saved Genshin Settings: {_ValueName}\r\n{JsonSerializer.Serialize(this, typeof(GeneralData), options_debug)}", LogType.Debug, true);
+#endif
+#if DEBUG
+                LogWriteLine($"Saved Genshin Settings: {_ValueName}" +
+                    $"\r\n      Text Language        : {deviceLanguageType}" +
+                    $"\r\n      VO Language          : {deviceVoiceLanguageType}" +
+                    $"\r\n      Audio - Master Volume: {volumeGlobal}" +
+                    $"\r\n      Audio - Music Volume : {volumeMusic}" +
+                    $"\r\n      Audio - SFX Volume   : {volumeSFX}" +
+                    $"\r\n      Audio - Voice Volume : {volumeVoice}" +
+                    $"\r\n      Audio - Dynamic Range: {audioDynamicRange}" +
+                    $"\r\n      Audio - Surround     : {audioOutput}" +
+                    $"\r\n      Gamma                : {gammaValue}", LogType.Debug);
+#else
+                LogWriteLine($"Saved Genshin Game Settings", LogType.Default, true);
 #endif
             }
             catch (Exception ex)
@@ -384,6 +380,6 @@ namespace CollapseLauncher.GameSettings.Genshin
 
         public bool Equals(GeneralData? comparedTo) => TypeExtensions.IsInstancePropertyEqual(this, comparedTo);
 #nullable disable
-        #endregion
+#endregion
     }
 }

--- a/CollapseLauncher/Classes/GameManagement/GameSettings/Genshin/RegistryClass/GeneralData.cs
+++ b/CollapseLauncher/Classes/GameManagement/GameSettings/Genshin/RegistryClass/GeneralData.cs
@@ -282,6 +282,12 @@ namespace CollapseLauncher.GameSettings.Genshin
 
         #region Methods
 #nullable enable
+#if DEBUG
+        // Set this to true if you want to dump the entire JSON of Genshin Settings to console
+        // Warning: Resource intensive!
+        private static bool DumpJSON = false;
+#endif
+
         public static GeneralData Load()
         {
             try
@@ -293,17 +299,20 @@ namespace CollapseLauncher.GameSettings.Genshin
                 {
                     ReadOnlySpan<byte> byteStr = (byte[])value;
 #if DEBUG
-                    // If you want to debug GeneralData, Append this to the LogWriteLine:
-                    // \r\n{Encoding.UTF8.GetString((byte[])value, 0, ((byte[])value).Length - 1)}
-                    // WARNING: VERY EXPENSIVE CPU TIME WILL BE USED
-                    //LogWriteLine($"Loaded Genshin Settings: {_ValueName}", LogType.Debug, true);
-                    JsonSerializerOptions options_debug = new JsonSerializerOptions()
+                    if (DumpJSON)
                     {
-                        TypeInfoResolver = GenshinSettingsJSONContext.Default,
-                        Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
-                        WriteIndented = true
-                    };
-                    LogWriteLine($"Loaded Genshin Settings: {_ValueName}\r\n{JsonSerializer.Serialize(JsonSerializer.Deserialize<GeneralData>(Encoding.UTF8.GetString((byte[])value, 0, ((byte[])value).Length - 1), options_debug), options_debug)}", LogType.Debug, true);
+                        LogWriteLine($"RAW Genshin Settings: {_ValueName}\r\n" +
+                            $"{Encoding.UTF8.GetString((byte[])value)}", LogType.Debug, true);
+
+                        JsonSerializerOptions options_debug = new JsonSerializerOptions()
+                        {
+                            TypeInfoResolver = GenshinSettingsJSONContext.Default,
+                            Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
+                            WriteIndented = true
+                        };
+                        LogWriteLine($"Deserialized Genshin Settings: {_ValueName}\r\n{JsonSerializer.Serialize(JsonSerializer.Deserialize<GeneralData>(Encoding.UTF8.GetString((byte[])value, 0, ((byte[])value).Length - 1), options_debug), options_debug)}", LogType.Debug, true);
+                    }
+                    else LogWriteLine($"Loaded Genshin Settings: {_ValueName}", LogType.Debug, true);
 #endif
                     JsonSerializerOptions options = new JsonSerializerOptions()
                     {
@@ -342,26 +351,29 @@ namespace CollapseLauncher.GameSettings.Genshin
 
                 RegistryRoot.SetValue(_ValueName, dataByte, RegistryValueKind.Binary);
 #if DEBUG
-                // Only tracking actually used items (besides GlobalPerfData and GraphicsData)
-                //LogWriteLine($"Saved Genshin Settings: {_ValueName}" +
-                //    $"\r\n      Text Language        : {deviceLanguageType}" +
-                //    $"\r\n      VO Language          : {deviceVoiceLanguageType}" +
-                //    $"\r\n      Audio - Master Volume: {volumeGlobal}" +
-                //    $"\r\n      Audio - Music Volume : {volumeMusic}" +
-                //    $"\r\n      Audio - SFX Volume   : {volumeSFX}" +
-                //    $"\r\n      Audio - Voice Volume : {volumeVoice}" +
-                //    $"\r\n      Audio - Dynamic Range: {audioDynamicRange}" +
-                //    $"\r\n      Audio - Surround     : {audioOutput}" +
-                //    $"\r\n      Gamma                : {gammaValue}", LogType.Debug);
-                // If you want to debug GeneralData, uncomment this LogWriteLine
-                // WARNING: VERY EXPENSIVE CPU TIME WILL BE USED
-                JsonSerializerOptions options_debug = new JsonSerializerOptions()
+                if (DumpJSON)
                 {
-                    TypeInfoResolver = GenshinSettingsJSONContext.Default,
-                    Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
-                    WriteIndented = true
-                };
-                LogWriteLine($"Saved Genshin Settings: {_ValueName}\r\n{JsonSerializer.Serialize(this, typeof(GeneralData), options_debug)}", LogType.Debug, true);
+                    JsonSerializerOptions options_debug = new JsonSerializerOptions()
+                    {
+                        TypeInfoResolver = GenshinSettingsJSONContext.Default,
+                        Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
+                        WriteIndented = true
+                    };
+                    LogWriteLine($"Saved Genshin Settings: {_ValueName}\r\n{JsonSerializer.Serialize(this, typeof(GeneralData), options_debug)}", LogType.Debug, true);
+                }
+                else
+                {
+                    LogWriteLine($"Saved Genshin Settings: {_ValueName}" +
+                        $"\r\n      Text Language        : {deviceLanguageType}" +
+                        $"\r\n      VO Language          : {deviceVoiceLanguageType}" +
+                        $"\r\n      Audio - Master Volume: {volumeGlobal}" +
+                        $"\r\n      Audio - Music Volume : {volumeMusic}" +
+                        $"\r\n      Audio - SFX Volume   : {volumeSFX}" +
+                        $"\r\n      Audio - Voice Volume : {volumeVoice}" +
+                        $"\r\n      Audio - Dynamic Range: {audioDynamicRange}" +
+                        $"\r\n      Audio - Surround     : {audioOutput}" +
+                        $"\r\n      Gamma                : {gammaValue}", LogType.Debug);
+                }
 #endif
             }
             catch (Exception ex)

--- a/CollapseLauncher/Classes/GameManagement/GameSettings/Genshin/RegistryClass/GeneralData.cs
+++ b/CollapseLauncher/Classes/GameManagement/GameSettings/Genshin/RegistryClass/GeneralData.cs
@@ -24,17 +24,7 @@ namespace CollapseLauncher.GameSettings.Genshin
         //Using guide from https://github.com/Myp3a/GenshinConfigurator/wiki/Config-format
         //Thanks Myp3a!
 
-        /// <summary>
-        /// deviceUUID<br/>
-        /// This is supposed to be empty
-        /// </summary>
         public string deviceUUID { get; set; } = "";
-
-        /// <summary>
-        /// userLocalDataVersionId<br/>
-        /// This should be static<br/>
-        /// Value: 0.0.1
-        /// </summary>
         public string userLocalDataVersionId { get; set; } = "0.0.1";
 
         /// <summary>
@@ -106,7 +96,7 @@ namespace CollapseLauncher.GameSettings.Genshin
 
         /// <summary>
         /// This is a dict that keeps track of graphics settings changes.<br/>
-        /// Save to ignore (?)
+        /// Always port graphicsData to this also, if not then settings are not applied.
         /// </summary>
         // Temporary for fallback before the implementation is made
         [JsonIgnore]
@@ -115,9 +105,7 @@ namespace CollapseLauncher.GameSettings.Genshin
         [JsonPropertyName("globalPerfData")]
         public string _globalPerfData { get; set; }
 
-        /// <summary>
-        /// Something about minimap config ?
-        /// </summary>
+
         public int miniMapConfig { get; set; } = 1;
 
         /// <summary>

--- a/CollapseLauncher/Classes/GameManagement/GameSettings/Genshin/RegistryClass/GeneralData.cs
+++ b/CollapseLauncher/Classes/GameManagement/GameSettings/Genshin/RegistryClass/GeneralData.cs
@@ -75,9 +75,6 @@ namespace CollapseLauncher.GameSettings.Genshin
         /// </summary>
         public string selectedServerName { get; set; } = "os_usa";
 
-        /// <summary>
-        /// I don't know what this do
-        /// </summary>
         public int localLevelIndex { get; set; } = 0;
         public string deviceID { get; set; } = "";
         public string targetUID { get; set; } = "";
@@ -118,9 +115,6 @@ namespace CollapseLauncher.GameSettings.Genshin
         [JsonPropertyName("globalPerfData")]
         public string _globalPerfData { get; set; }
 
-        //[JsonIgnore]
-        //public globalPerfData globalPerfData { get; set; }
-
         /// <summary>
         /// Something about minimap config ?
         /// </summary>
@@ -132,31 +126,11 @@ namespace CollapseLauncher.GameSettings.Genshin
         /// </summary>
         public bool enableCameraSlope { get; set; } = true;
 
-        /// <summary>
-        /// This defines "<c>Smart combat camera</c>" whatever that is.<br/>
-        /// Default: true
-        /// </summary>
         public bool enableCameraCombatLock { get; set; } = true;
-
-        /// <summary>
-        /// not sure either what these does.
-        /// </summary>
         public bool completionPkg { get; set; } = false;
         public bool completionPlayGoPkg { get; set; } = false;
-
-        /// <summary>
-        /// Could be for PlayStation multiplayer stuff
-        /// </summary>
         public bool onlyPlayWithPSPlayer { get; set; } = false;
-
-        /// <summary>
-        /// Mysterious~
-        /// </summary>
         public bool needPlayGoFullPkgPatch { get; set; } = false;
-
-        /// <summary>
-        /// Mobile notification stuff
-        /// </summary>
         public bool resinNotification { get; set; } = true;
         public bool exploreNotification { get; set; } = true;
 
@@ -207,9 +181,6 @@ namespace CollapseLauncher.GameSettings.Genshin
         /// </summary>
         public int audioOutput { get; set; } = 0;
 
-        /// <summary>
-        /// Audio related stuff...
-        /// </summary>
         public bool _audioSuccessInit { get; set; } = true;
         public bool enableAudioChangeAndroidMinimumBufferCapacity { get; set; } = true;
         public int audioAndroidMiniumBufferCapacity { get; set; } = 2048;
@@ -228,18 +199,15 @@ namespace CollapseLauncher.GameSettings.Genshin
         /// </summary>
         public int vibrationIntensity { get; set; } = 5;
 
-        /// <summary>
-        /// Some vibration related stuff ?
-        /// </summary>
         public bool usingNewVibrationSetting { get; set; } = true;
 
         /// <summary>
-        /// Is not an actual blur setting
+        /// Is not an actual blur setting, look at GraphicsData for the real deal.
         /// </summary>
         public bool motionBlur { get; set; } = true;
 
         /// <summary>
-        /// Gyro Aiming stuff, most likely not used in PC.
+        /// Gyro Aiming controls, used for those who use controller that has Gyro control.
         /// </summary>
         public bool gyroAiming { get; set; } = false;
         public int gyroHorMoveSpeedIndex { get; set; } = 2;
@@ -250,6 +218,7 @@ namespace CollapseLauncher.GameSettings.Genshin
         public bool gyroExcludeRightStickVerInput { get; set; } = false;
 
         //unsure what these does, probably HDR stuff? doesn't have HDR monitor to test...
+        //also doesn't seem to be tied into any actual game settings as Genshin doesn't have a native HDR
         public bool firstHDRSetting { get; set; } = true;
         public decimal maxLuminosity { get; set; } = 0.0m;
         public decimal uiPaperWhite { get; set; } = 0.0m;
@@ -257,6 +226,8 @@ namespace CollapseLauncher.GameSettings.Genshin
 
         /// <summary>
         /// This defines "<c>Gamma</c>" slider in-game. <br/>
+        /// Accepted values : 1.4f - 3.0f <br/>
+        /// <c>WARNING:</c> Value is inverted
         /// </summary>
         public double gammaValue { get; set; } = 2.2f;
 
@@ -278,8 +249,6 @@ namespace CollapseLauncher.GameSettings.Genshin
         //[JsonIgnore]
         //public Controllers _overrideControllerMapValueList { get; set; }
 
-        //misc values
-        //just, idk, ignore?
         public bool rewiredDisableKeyboard { get; set; } = false;
         public bool rewiredEnableKeyboard { get; set; } = false;
         public bool rewiredEnableEDS { get; set; } = false;
@@ -290,7 +259,10 @@ namespace CollapseLauncher.GameSettings.Genshin
         public bool forceDisableQuestResourceManagement { get; set; } = false;
         public bool needReportQuestResourceDeleteStatusFiles { get; set; } = false;
 
-        // disableTeamPageBackgroundSwitch (bool false)
+        /// <summary>
+        /// This defines "<c>The background of the Party Setup screen will change based on your current region</c>" in-game combo box <br/>
+        /// Default: true
+        /// </summary>
         public bool disableTeamPageBackgroundSwitch { get; set; } = false;
 
         public bool mtrCached { get; set; } = true;

--- a/CollapseLauncher/Classes/GameManagement/GameSettings/Genshin/RegistryClass/GeneralData.cs
+++ b/CollapseLauncher/Classes/GameManagement/GameSettings/Genshin/RegistryClass/GeneralData.cs
@@ -307,7 +307,7 @@ namespace CollapseLauncher.GameSettings.Genshin
         public List<string> _customDataValueList { get; set; }
         public List<int> _serializedCodeSwitches { get; set; }
         public bool urlCheckCached { get; set; } = false;
-        public bool urlCheckIsOpen { get; set; } = false;
+        public bool urlCheckIsOpen { get; set; } = true;
         public bool urlCheckAllIP { get; set; } = false;
         public int urlCheckTimeOut { get; set; } = 5000;
         public int urlCheckSueecssTraceCount { get; set; } = 5;

--- a/CollapseLauncher/Classes/GameManagement/GameSettings/Genshin/RegistryClass/GeneralData.cs
+++ b/CollapseLauncher/Classes/GameManagement/GameSettings/Genshin/RegistryClass/GeneralData.cs
@@ -334,9 +334,16 @@ namespace CollapseLauncher.GameSettings.Genshin
                     ReadOnlySpan<byte> byteStr = (byte[])value;
 #if DEBUG
                     // If you want to debug GeneralData, Append this to the LogWriteLine:
-                    // '\r\n{Encoding.UTF8.GetString((byte[])value, 0, ((byte[])value).Length - 1)'
+                    // \r\n{Encoding.UTF8.GetString((byte[])value, 0, ((byte[])value).Length - 1)}
                     // WARNING: VERY EXPENSIVE CPU TIME WILL BE USED
-                    LogWriteLine($"Loaded Genshin Settings: {_ValueName}", LogType.Debug, true);
+                    //LogWriteLine($"Loaded Genshin Settings: {_ValueName}", LogType.Debug, true);
+                    JsonSerializerOptions options_debug = new JsonSerializerOptions()
+                    {
+                        TypeInfoResolver = GenshinSettingsJSONContext.Default,
+                        Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
+                        WriteIndented = true
+                    };
+                    LogWriteLine($"Loaded Genshin Settings: {_ValueName}\r\n{JsonSerializer.Serialize(JsonSerializer.Deserialize<GeneralData>(Encoding.UTF8.GetString((byte[])value, 0, ((byte[])value).Length - 1), options_debug), options_debug)}", LogType.Debug, true);
 #endif
                     JsonSerializerOptions options = new JsonSerializerOptions()
                     {
@@ -376,19 +383,25 @@ namespace CollapseLauncher.GameSettings.Genshin
                 RegistryRoot.SetValue(_ValueName, dataByte, RegistryValueKind.Binary);
 #if DEBUG
                 // Only tracking actually used items (besides GlobalPerfData and GraphicsData)
-                LogWriteLine($"Saved Genshin Settings: {_ValueName}" +
-                    $"\r\n      Text Language        : {deviceLanguageType}" +
-                    $"\r\n      VO Language          : {deviceVoiceLanguageType}" +
-                    $"\r\n      Audio - Master Volume: {volumeGlobal}" +
-                    $"\r\n      Audio - Music Volume : {volumeMusic}" +
-                    $"\r\n      Audio - SFX Volume   : {volumeSFX}" +
-                    $"\r\n      Audio - Voice Volume : {volumeVoice}" +
-                    $"\r\n      Audio - Dynamic Range: {audioDynamicRange}" +
-                    $"\r\n      Audio - Surround     : {audioOutput}" +
-                    $"\r\n      Gamma                : {gammaValue}", LogType.Debug);
+                //LogWriteLine($"Saved Genshin Settings: {_ValueName}" +
+                //    $"\r\n      Text Language        : {deviceLanguageType}" +
+                //    $"\r\n      VO Language          : {deviceVoiceLanguageType}" +
+                //    $"\r\n      Audio - Master Volume: {volumeGlobal}" +
+                //    $"\r\n      Audio - Music Volume : {volumeMusic}" +
+                //    $"\r\n      Audio - SFX Volume   : {volumeSFX}" +
+                //    $"\r\n      Audio - Voice Volume : {volumeVoice}" +
+                //    $"\r\n      Audio - Dynamic Range: {audioDynamicRange}" +
+                //    $"\r\n      Audio - Surround     : {audioOutput}" +
+                //    $"\r\n      Gamma                : {gammaValue}", LogType.Debug);
                 // If you want to debug GeneralData, uncomment this LogWriteLine
                 // WARNING: VERY EXPENSIVE CPU TIME WILL BE USED
-                // LogWriteLine($"Saved Genshin Settings: {_ValueName}\r\n{Encoding.UTF8.GetString((byte[])value, 0, ((byte[])value).Length - 1)", LogType.Debug, true);
+                JsonSerializerOptions options_debug = new JsonSerializerOptions()
+                {
+                    TypeInfoResolver = GenshinSettingsJSONContext.Default,
+                    Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
+                    WriteIndented = true
+                };
+                LogWriteLine($"Saved Genshin Settings: {_ValueName}\r\n{JsonSerializer.Serialize(this, typeof(GeneralData), options_debug)}", LogType.Debug, true);
 #endif
             }
             catch (Exception ex)

--- a/CollapseLauncher/Classes/GameManagement/GameSettings/Genshin/RegistryClass/GeneralData.cs
+++ b/CollapseLauncher/Classes/GameManagement/GameSettings/Genshin/RegistryClass/GeneralData.cs
@@ -24,76 +24,6 @@ namespace CollapseLauncher.GameSettings.Genshin
         //Using guide from https://github.com/Myp3a/GenshinConfigurator/wiki/Config-format
         //Thanks Myp3a!
 
-        public int mtrAbortTimeOutCount { get; set; } = 3;
-
-        /// <summary>
-        /// Could be for PlayStation multiplayer stuff
-        /// </summary>
-        public bool onlyPlayWithPSPlayer { get; set; } = false;
-
-        public int urlCheckErrorTraceCount { get; set; } = 30;
-
-        public decimal uiPaperWhite { get; set; } = 0.0m;
-        public decimal scenePaperWhite { get; set; } = 0.0m;
-
-        public int localLevelIndex { get; set; } = 0;
-        public bool disableRewiredDelayInit { get; set; } = false;
-        public bool enableAudioChangeAndroidMinimumBufferCapacity { get; set; } = true;
-
-        /// <summary>
-        /// This define "<c>Voice Volume</c>" slider in-game.<br/>
-        /// Valid values: 0-10
-        /// Default: 10
-        /// </summary>
-        public int volumeVoice { get; set; } = 10;
-
-        public int mtrTraceCDEachReason { get; set; } = 600;
-        public bool mtrCached { get; set; } = true;
-        public List<object> urlCheckBanReasons { get; set; }
-
-        /// <summary>
-        /// This define "<c>Server Name</c>" last selected in loading menu. <br/>
-        /// </summary>
-        public string selectedServerName { get; set; } = "os_usa";
-
-        public int urlCheckTimeInterval { get; set; } = 1000;
-        public int lastSeenPreDownloadTime { get; set; } = 0;
-
-        /// <summary>
-        /// This holds settings that holds Graphics Settings settings. YEP!<br/>
-        /// Needs to be serialized again with its keys and values in dictionary<br/>
-        /// https://github.com/Myp3a/GenshinConfigurator/wiki/Config-format#graphics-data-format
-        /// </summary>
-        [JsonPropertyName("graphicsData")]
-        public string _graphicsData { get; set; }
-
-        [JsonIgnore]
-        public GraphicsData graphicsData { get; set; }
-
-        public bool completionPlayGoPkg { get; set; } = false;
-
-        /// <summary>
-        /// This defines "<c>Gamma</c>" slider in-game. <br/>
-        /// This implementation is quite janky but hear me out <br/>
-        /// The value is directly controlled by Gamma Slider, which linked with GammaValue (NumberBox) <br/>
-        /// Since the value is flipped, math function of y = -x + 4.4 is used (Refer GenshinGameSettingsPage.Ext.cs Line 122)
-        /// </summary>
-        public double gammaValue { get; set; } = 2.2f;
-
-        public bool mtrIsOpen { get; set; } = true;
-
-        /// <summary>
-        /// This defines "<c>Vibration Intensity</c>" slider in-game. <br/>
-        /// Valid Values: 1-5
-        /// Default: 5
-        /// </summary>
-        public int vibrationIntensity { get; set; } = 5;
-
-        public bool needPlayGoFullPkgPatch { get; set; } = false;
-        public bool exploreNotification { get; set; } = true;
-        public int mtrMaxTTL { get; set; } = 32;
-        public bool urlCheckCached { get; set; } = false;
-
         /// <summary>
         /// deviceUUID<br/>
         /// This is supposed to be empty
@@ -101,103 +31,11 @@ namespace CollapseLauncher.GameSettings.Genshin
         public string deviceUUID { get; set; } = "";
 
         /// <summary>
-        /// This defines "<c>Smart combat camera</c>" whatever that is.<br/>
-        /// Default: true
+        /// userLocalDataVersionId<br/>
+        /// This should be static<br/>
+        /// Value: 0.0.1
         /// </summary>
-        public bool enableCameraCombatLock { get; set; } = true;
-
-        public bool enableEffectAssembleInEditor { get; set; } = true;
-        public bool resinNotification { get; set; } = true;
-
-        /// <summary>
-        /// This define "<c>Voice Language</c>" in-game settings. <br/>
-        /// Valid values: 0-3
-        /// Default: 1
-        /// Chinese(0)
-        /// English(1)
-        /// Japanese(2)
-        /// Korean(3)
-        /// </summary>
-        public int deviceVoiceLanguageType { get; set; } = 1;
-
-        public string curAccountName { get; set; } = "";
-        public bool _audioSuccessInit { get; set; } = true;
-        public bool urlCheckAllIP { get; set; } = false;
-        public bool rewiredDisableKeyboard { get; set; } = false;
-
-        /// <summary>
-        /// This defines "<c>Audio Output</c>" combo box in-game.
-        /// Valid Values: 0 (stereo), 1 (surround)
-        /// Default: 0
-        /// </summary>
-        public int audioOutput { get; set; } = 0;
-
-        public int miniMapConfig { get; set; } = 1;
-
-        /// <summary>
-        /// This  defines "<c>Automatic View Height</c>" in-game settings.<br/>
-        /// Default: true
-        /// </summary>
-        public bool enableCameraSlope { get; set; } = true;
-
-        /// <summary>
-        /// This define vibration level for certain controller probably ?
-        /// Valid Values: 0 (Full), 1 (Partial), 2 (Off)
-        /// Default: 0
-        /// </summary>
-        public int vibrationLevel { get; set; } = 0;
-
-        public string deviceID { get; set; } = "";
-        public string uiSaveData { get; set; }
-        public bool gyroAiming { get; set; } = false;
-        public bool motionBlur { get; set; } = true;
-        public bool completionPkg { get; set; } = false;
-        public int audioAndroidMiniumBufferCapacity { get; set; } = 2048;
-
-        /// <summary>
-        /// This is a dict that keeps track of graphics settings changes.<br/>
-        /// Save to ignore (?)
-        /// </summary>
-        [JsonIgnore]
-        public GlobalPerfData globalPerfData { get; set; }
-
-        [JsonPropertyName("globalPerfData")]
-        public string _globalPerfData { get; set; }
-
-        public int urlCheckTimeOut { get; set; } = 5000;
-        public int audioAPI { get; set; } = -1;
-
-        /// <summary>
-        /// This defines "<c>Dynamic Range</c>" audio combo box in-game.
-        /// Valid values: 0 (full), 1 (limited)
-        /// Default: 0
-        /// </summary>
-        public int audioDynamicRange { get; set; } = 0;
-
-        public bool firstHDRSetting { get; set; } = true;
-        public int mtrTraceCount { get; set; } = 5;
-        public bool disableRewiredInitProtection { get; set; } = false;
-        public string greyTestDeviceUniqueId { get; set; } = "";
-        public bool mtrUseOldWinVersion { get; set; } = false;
-        public List<int> _serializedCodeSwitches { get; set; }
-        public int urlCheckAbortTimeOutCount { get; set; } = 3;
-        public int urlCheckSueecssTraceCount { get; set; } = 5; //yes, that is actually the class name, its not a typo by us...
-
-        /// <summary>
-        /// This define "<c>Music Volume</c>" slider in-game.<br/>
-        /// Valid values: 0-10
-        /// Default: 10
-        /// </summary>
-        public int volumeMusic { get; set; } = 10;
-
-        /// <summary>
-        /// This holds value for controllers input that has been customized.
-        /// </summary>
-        public List<string> _overrideControllerMapKeyList { get; set; }
-
-        public bool urlCheckIsOpen { get; set; } = false;
-        public int urlCheckCDEachReason { get; set; } = 600;
-        public List<string> _customDataValueList { get; set; }
+        public string userLocalDataVersionId { get; set; } = "0.0.1";
 
         /// <summary>
         /// This define "<c>Text Language</c>" in-game settings. <br/>
@@ -221,27 +59,106 @@ namespace CollapseLauncher.GameSettings.Genshin
         /// </summary>
         public int deviceLanguageType { get; set; } = 1;
 
-        public List<string> _customDataKeyList { get; set; }
-        public List<object> mtrBanReasons { get; set; }
-        public int mtrTimeInterval { get; set; } = 1000;
-
         /// <summary>
-        /// This define "<c>SFX Volume</c>" slider in-game.<br/>
-        /// Valid values: 0-10
-        /// Default: 10
+        /// This define "<c>Voice Language</c>" in-game settings. <br/>
+        /// Valid values: 0-3
+        /// Default: 1
+        /// Chinese(0)
+        /// English(1)
+        /// Japanese(2)
+        /// Korean(3)
         /// </summary>
-        public int volumeSFX { get; set; } = 10;
-
-        public int mtrAutoTraceInterval { get; set; } = 3600;
-        public bool needReportQuestResourceDeleteStatusFiles { get; set; } = false;
+        public int deviceVoiceLanguageType { get; set; } = 1;
 
         /// <summary>
-        /// This holds said override for those controllers.
+        /// This define "<c>Server Name</c>" last selected in loading menu. <br/>
+        /// </summary>
+        public string selectedServerName { get; set; } = "os_usa";
+
+        /// <summary>
+        /// I don't know what this do
+        /// </summary>
+        public int localLevelIndex { get; set; } = 0;
+        public string deviceID { get; set; } = "";
+        public string targetUID { get; set; } = "";
+        public string curAccountName { get; set; } = "";
+
+        /// <summary>
+        /// This define "<c>Resolution</c>" index selected in-game. <br/>
+        /// Valid value: 0-?
+        /// Default: 0
+        /// </summary>
+        public string uiSaveData { get; set; }
+
+        /// <summary>
+        /// This holds settings for input sens and stuff.<br/>
+        /// Please look at https://github.com/Myp3a/GenshinConfigurator/wiki/Config-format#input-data-format
+        /// </summary>
+        public string inputData { get; set; }
+
+        /// <summary>
+        /// This holds settings that holds Graphics Settings settings. YEP!<br/>
+        /// Needs to be serialized again with its keys and values in dictionary<br/>
+        /// https://github.com/Myp3a/GenshinConfigurator/wiki/Config-format#graphics-data-format
+        /// </summary>
+        [JsonPropertyName("graphicsData")]
+        public string _graphicsData { get; set; }
+
+        [JsonIgnore]
+        public GraphicsData graphicsData { get; set; }
+
+        /// <summary>
+        /// This is a dict that keeps track of graphics settings changes.<br/>
+        /// Save to ignore (?)
         /// </summary>
         // Temporary for fallback before the implementation is made
-        public List<string> _overrideControllerMapValueList { get; set; }
+        [JsonIgnore]
+        public GlobalPerfData globalPerfData { get; set; }
 
-        public int mtrTimeOut { get; set; } = 5000;
+        [JsonPropertyName("globalPerfData")]
+        public string _globalPerfData { get; set; }
+
+        //[JsonIgnore]
+        //public globalPerfData globalPerfData { get; set; }
+
+        /// <summary>
+        /// Something about minimap config ?
+        /// </summary>
+        public int miniMapConfig { get; set; } = 1;
+
+        /// <summary>
+        /// This  defines "<c>Automatic View Height</c>" in-game settings.<br/>
+        /// Default: true
+        /// </summary>
+        public bool enableCameraSlope { get; set; } = true;
+
+        /// <summary>
+        /// This defines "<c>Smart combat camera</c>" whatever that is.<br/>
+        /// Default: true
+        /// </summary>
+        public bool enableCameraCombatLock { get; set; } = true;
+
+        /// <summary>
+        /// not sure either what these does.
+        /// </summary>
+        public bool completionPkg { get; set; } = false;
+        public bool completionPlayGoPkg { get; set; } = false;
+
+        /// <summary>
+        /// Could be for PlayStation multiplayer stuff
+        /// </summary>
+        public bool onlyPlayWithPSPlayer { get; set; } = false;
+
+        /// <summary>
+        /// Mysterious~
+        /// </summary>
+        public bool needPlayGoFullPkgPatch { get; set; } = false;
+
+        /// <summary>
+        /// Mobile notification stuff
+        /// </summary>
+        public bool resinNotification { get; set; } = true;
+        public bool exploreNotification { get; set; } = true;
 
         /// <summary>
         /// This define "<c>Global Volume</c>" slider in-game.<br/>
@@ -250,28 +167,157 @@ namespace CollapseLauncher.GameSettings.Genshin
         /// </summary>
         public int volumeGlobal { get; set; } = 10;
 
-        public decimal maxLuminosity { get; set; } = 0.0m;
+        /// <summary>
+        /// This define "<c>SFX Volume</c>" slider in-game.<br/>
+        /// Valid values: 0-10
+        /// Default: 10
+        /// </summary>
+        public int volumeSFX { get; set; } = 10;
 
         /// <summary>
-        /// userLocalDataVersionId<br/>
-        /// This should be static<br/>
-        /// Empty value
+        /// This define "<c>Music Volume</c>" slider in-game.<br/>
+        /// Valid values: 0-10
+        /// Default: 10
         /// </summary>
-        public string userLocalDataVersionId { get; set; } = "";
+        public int volumeMusic { get; set; } = 10;
 
-        public bool forceDisableQuestResourceManagement { get; set; } = false;
-        public bool rewiredEnableEDS { get; set; } = false;
+        /// <summary>
+        /// This define "<c>Voice Volume</c>" slider in-game.<br/>
+        /// Valid values: 0-10
+        /// Default: 10
+        /// </summary>
+        public int volumeVoice { get; set; } = 10;
+
+        /// <summary>
+        /// Probably just leave it alone...
+        /// </summary>
+        public int audioAPI { get; set; } = -1;
+
+        /// <summary>
+        /// This defines "<c>Dynamic Range</c>" audio combo box in-game.
+        /// Valid values: 0 (full), 1 (limited)
+        /// Default: 0
+        /// </summary>
+        public int audioDynamicRange { get; set; } = 0;
+
+        /// <summary>
+        /// This defines "<c>Audio Output</c>" combo box in-game.
+        /// Valid Values: 0 (stereo), 1 (surround)
+        /// Default: 0
+        /// </summary>
+        public int audioOutput { get; set; } = 0;
+
+        /// <summary>
+        /// Audio related stuff...
+        /// </summary>
+        public bool _audioSuccessInit { get; set; } = true;
+        public bool enableAudioChangeAndroidMinimumBufferCapacity { get; set; } = true;
+        public int audioAndroidMiniumBufferCapacity { get; set; } = 2048;
+
+        /// <summary>
+        /// This define vibration level for certain controller probably ?
+        /// Valid Values: 0 (Full), 1 (Partial), 2 (Off)
+        /// Default: 0
+        /// </summary>
+        public int vibrationLevel { get; set; } = 0;
+
+        /// <summary>
+        /// This defines "<c>Vibration Intensity</c>" slider in-game. <br/>
+        /// Valid Values: 1-5
+        /// Default: 5
+        /// </summary>
+        public int vibrationIntensity { get; set; } = 5;
+
+        /// <summary>
+        /// Some vibration related stuff ?
+        /// </summary>
         public bool usingNewVibrationSetting { get; set; } = true;
 
         /// <summary>
-        /// This holds settings for input sens and stuff.<br/>
-        /// Please look at https://github.com/Myp3a/GenshinConfigurator/wiki/Config-format#input-data-format
+        /// Is not an actual blur setting
         /// </summary>
-        public string inputData { get; set; }
+        public bool motionBlur { get; set; } = true;
 
-        public string targetUID { get; set; } = "";
+        /// <summary>
+        /// Gyro Aiming stuff, most likely not used in PC.
+        /// </summary>
+        public bool gyroAiming { get; set; } = false;
+        public int gyroHorMoveSpeedIndex { get; set; } = 2;
+        public int gyroVerMoveSpeedIndex { get; set; } = 2;
+        public bool gyroHorReverse { get; set; } = false;
+        public bool gyroVerReverse { get; set; } = false;
+        public int gyroRotateType { get; set; } = 0;
+        public bool gyroExcludeRightStickVerInput = false;
+
+        //unsure what these does, probably HDR stuff? doesn't have HDR monitor to test...
+        public bool firstHDRSetting { get; set; } = true;
+        public decimal maxLuminosity { get; set; } = 0.0m;
+        public decimal uiPaperWhite { get; set; } = 0.0m;
+        public decimal scenePaperWhite { get; set; } = 0.0m;
+
+        /// <summary>
+        /// This defines "<c>Gamma</c>" slider in-game. <br/>
+        /// </summary>
+        public double gammaValue { get; set; } = 2.2f;
+
+        /// <summary>
+        /// This holds value for controllers input that has been customized.
+        /// </summary>
+        public List<string> _overrideControllerMapKeyList { get; set; }
+
+
+        /// <summary>
+        /// This holds said override for those controllers.
+        /// </summary>
+        // Temporary for fallback before the implementation is made
+        public List<string> _overrideControllerMapValueList { get; set; }
+
+        //[JsonPropertyName("_overrideControllerMapValueList")]
+        //public List<string> __overrideControllerMapValueList { get; set; }
+
+        //[JsonIgnore]
+        //public Controllers _overrideControllerMapValueList { get; set; }
+
+        //misc values
+        //just, idk, ignore?
+        public bool rewiredDisableKeyboard { get; set; } = false;
         public bool rewiredEnableKeyboard { get; set; } = false;
+        public bool rewiredEnableEDS { get; set; } = false;
+        public bool disableRewiredDelayInit { get; set; } = false;
+        public bool disableRewiredInitProtection { get; set; } = false;
+        public int lastSeenPreDownloadTime { get; set; } = 0;
+        public bool enableEffectAssembleInEditor { get; set; } = true;
+        public bool forceDisableQuestResourceManagement { get; set; } = false;
+        public bool needReportQuestResourceDeleteStatusFiles { get; set; } = false;
 
+        // disableTeamPageBackgroundSwitch (bool false)
+        public bool disableTeamPageBackgroundSwitch { get; set; } = false;
+
+        public bool mtrCached { get; set; } = true;
+        public bool mtrIsOpen { get; set; } = true;
+        public int mtrMaxTTL { get; set; } = 32;
+        public int mtrTimeOut { get; set; } = 5000;
+        public int mtrTraceCount { get; set; } = 5;
+        public int mtrAbortTimeOutCount { get; set; } = 3;
+        public int mtrAutoTraceInterval { get; set; } = 3600;
+        public int mtrTraceCDEachReason { get; set; } = 600;
+        public int mtrTimeInterval { get; set; } = 1000;
+        public List<object> mtrBanReasons { get; set; }
+        public List<string> _customDataKeyList { get; set; }
+        public List<string> _customDataValueList { get; set; }
+        public List<int> _serializedCodeSwitches { get; set; }
+        public bool urlCheckCached { get; set; } = false;
+        public bool urlCheckIsOpen { get; set; } = false;
+        public bool urlCheckAllIP { get; set; } = false;
+        public int urlCheckTimeOut { get; set; } = 5000;
+        public int urlCheckSueecssTraceCount { get; set; } = 5;
+        public int urlCheckErrorTraceCount { get; set; } = 30;
+        public int urlCheckAbortTimeOutCount { get; set; } = 3;
+        public int urlCheckTimeInterval { get; set; } = 1000;
+        public int urlCheckCDEachReason { get; set; } = 600;
+        public List<object> urlCheckBanReasons { get; set; }
+        public bool mtrUseOldWinVersion { get; set; } = false;
+        public string greyTestDeviceUniqueId { get; set; } = "";
         #endregion
 
         #region Methods

--- a/CollapseLauncher/Classes/GameManagement/GameSettings/Genshin/RegistryClass/GlobalPerfData.cs
+++ b/CollapseLauncher/Classes/GameManagement/GameSettings/Genshin/RegistryClass/GlobalPerfData.cs
@@ -69,6 +69,7 @@ namespace CollapseLauncher.GameSettings.Genshin
                 new PerfDataItem (16,(int) graphics.CoOpTeammateEffects - 1, version),
                 new PerfDataItem (15,(int) graphics.SubsurfaceScattering - 1, version),
                 new PerfDataItem (17,(int) graphics.AnisotropicFiltering - 1, version),
+                new PerfDataItem (19,(int) graphics.GlobalIllumination - 1, version)
             };
             string data = JsonSerializer.Serialize(this, typeof(GlobalPerfData), GenshinSettingsJSONContext.Default);
 #if DEBUG

--- a/CollapseLauncher/Classes/GameManagement/GameSettings/Genshin/RegistryClass/GraphicsData.cs
+++ b/CollapseLauncher/Classes/GameManagement/GameSettings/Genshin/RegistryClass/GraphicsData.cs
@@ -6,8 +6,8 @@ using System.Linq;
 using System.Text.Encodings.Web;
 using System.Text.Json;
 using Hi3Helper;
-
 using static Hi3Helper.Logger;
+
 namespace CollapseLauncher.GameSettings.Genshin
 {
     internal class GraphicsData
@@ -37,63 +37,63 @@ namespace CollapseLauncher.GameSettings.Genshin
         #region Settings
         /// <summary>
         /// This defines "<c>FPS</c>" combobox In-game settings. <br/>
-        /// Options: 30, 60, 45
+        /// Options: 30, 60, 45 <br/>
         /// Default: 60 [1]
         /// </summary>
         public FPSOption FPS = FPSOption.f60;
 
         /// <summary>
         /// This defines "<c>Render Resolution</c>" combobox In-game settings. <br/>
-        /// Options: 0.6, 0.8, 1.0, 1.1, 1.2, 1.3, 1.4, 1.5
+        /// Options: 0.6, 0.8, 1.0, 1.1, 1.2, 1.3, 1.4, 1.5 <br/>
         /// Default: 1.0 [3]
         /// </summary>
         public RenderResolutionOption RenderResolution = RenderResolutionOption.x10;
 
         /// <summary>
         /// This defines "<c>Shadow Quality</c>" combobox In-game settings. <br/>
-        /// Options: Lowest, Low, Medium, High
+        /// Options: Lowest, Low, Medium, High <br/>
         /// Default: High [4]
         /// </summary>
         public ShadowQualityOption ShadowQuality = ShadowQualityOption.High;
 
         /// <summary>
         /// This defines "<c>Visual Effects</c>" combobox In-game settings. <br/>
-        /// Options: Lowest, Low, Medium, High
+        /// Options: Lowest, Low, Medium, High <br/>
         /// Default: High [4]
         /// </summary>
         public VisualEffectsOption VisualEffects = VisualEffectsOption.High;
 
         /// <summary>
         /// This defines "<c>SFX Quality</c>" combobox In-game settings. <br/>
-        /// Options: Lowest, Low, Medium, High
+        /// Options: Lowest, Low, Medium, High <br/>
         /// Default: High [4]
         /// </summary>
         public SFXQualityOption SFXQuality = SFXQualityOption.High;
 
         /// <summary>
         /// This defines "<c>Environment Detail</c>" combobox In-game settings. <br/>
-        /// Options: Lowest, Low, Medium, High, Highest
+        /// Options: Lowest, Low, Medium, High, Highest <br/>
         /// Default: High [4]
         /// </summary>
         public EnvironmentDetailOption EnvironmentDetail = EnvironmentDetailOption.High;
 
         /// <summary>
         /// This defines "<c>Vertical Sync</c>" combobox In-game settings. <br/>
-        /// Options: Off, On
+        /// Options: Off, On <br/>
         /// Default: On [2]
         /// </summary>
         public VerticalSyncOption VerticalSync = VerticalSyncOption.On;
 
         /// <summary>
         /// This defines "<c>Antialiasing</c>" combobox In-game settings. <br/>
-        /// Options: Off, FSR 2, SMAA
+        /// Options: Off, FSR 2, SMAA <br/>
         /// Default: FSR 2 [2]
         /// </summary>
         public AntialiasingOption Antialiasing = AntialiasingOption.FSR2;
 
         /// <summary>
         /// This defines "<c>Volumetric Fog</c>" combobox In-game settings. <br/>
-        /// Options: Off, On
+        /// Options: Off, On <br/>
         /// Default: On [2]
         /// Game prohibits enabling this if "<c>Shadow Quality</c>" on Low or Lowest
         /// </summary>
@@ -101,57 +101,59 @@ namespace CollapseLauncher.GameSettings.Genshin
 
         /// <summary>
         /// This defines "<c>Reflections</c>" combobox In-game settings. <br/>
-        /// Options: Off, On
+        /// Options: Off, On <br/>
         /// Default: On [2]
         /// </summary>
         public ReflectionsOption Reflections = ReflectionsOption.On;
 
         /// <summary>
         /// This defines "<c>Motion Blur</c>" combobox In-game settings. <br/>
-        /// Options: Off, Low, High, Extreme
+        /// Options: Off, Low, High, Extreme <br/>
         /// Default: Extreme [4]
         /// </summary>
         public MotionBlurOption MotionBlur = MotionBlurOption.Extreme;
 
         /// <summary>
         /// This defines "<c>Bloom</c>" combobox In-game settings. <br/>
-        /// Options: Off, On
+        /// Options: Off, On <br/>
         /// Default: On [2]
         /// </summary>
         public BloomOption Bloom = BloomOption.On;
 
         /// <summary>
         /// This defines "<c>Crowd Density</c>" combobox In-game settings. <br/>
-        /// Options: Low, High
+        /// Options: Low, High <br/>
         /// Default: High [2]
         /// </summary>
         public CrowdDensityOption CrowdDensity = CrowdDensityOption.High;
 
         /// <summary>
         /// This defines "<c>Subsurface Scattering</c>" combobox In-game settings. <br/>
-        /// Options: Off, Medium, High
+        /// Options: Off, Medium, High <br/>
         /// Default: High [3]
         /// </summary>
         public SubsurfaceScatteringOption SubsurfaceScattering = SubsurfaceScatteringOption.High;
 
         /// <summary>
         /// This defines "<c>Co-Op Teammate Effects</c>" combobox In-game settings. <br/>
-        /// Options: Off, Partially Off, On
+        /// Options: Off, Partially Off, On <br/>
         /// Default: On [3]
         /// </summary>
         public CoOpTeammateEffectsOption CoOpTeammateEffects = CoOpTeammateEffectsOption.On;
 
         /// <summary>
         /// This defines "<c>Anisotropic Filtering</c>" combobox In-game settings. <br/>
-        /// Options: 1x, 2x, 4x, 8x, 16x
+        /// Options: 1x, 2x, 4x, 8x, 16x <br/>
         /// Default: 8x [4]
         /// </summary>
         public AnisotropicFilteringOption AnisotropicFiltering = AnisotropicFilteringOption.x8;
 
         /// <summary>
-        /// This defines "<c>Anisotropic Filtering</c>" combobox In-game settings. <br/>
-        /// Options: 1x, 2x, 4x, 8x, 16x
-        /// Default: 8x [4]
+        /// This defines "<c>Global Illumination</c>" combobox In-game settings. <br/>
+        /// Options: Off, Medium, High, Extreme
+        /// Default: Off [1]  <br/>
+        /// Notes: Only work for PC who meet the specs for Global Illumination, specified by HYV  <br/>
+        /// Further information: https://genshin.hoyoverse.com/en/news/detail/112690#:~:text=Minimum%20Specifications%20for%20Global%20Illumination
         /// </summary>
         public GlobalIlluminationOption GlobalIllumination = GlobalIlluminationOption.Off;
         #endregion

--- a/CollapseLauncher/Classes/GameManagement/GameSettings/Genshin/RegistryClass/GraphicsData.cs
+++ b/CollapseLauncher/Classes/GameManagement/GameSettings/Genshin/RegistryClass/GraphicsData.cs
@@ -147,6 +147,13 @@ namespace CollapseLauncher.GameSettings.Genshin
         /// Default: 8x [4]
         /// </summary>
         public AnisotropicFilteringOption AnisotropicFiltering = AnisotropicFilteringOption.x8;
+
+        /// <summary>
+        /// This defines "<c>Anisotropic Filtering</c>" combobox In-game settings. <br/>
+        /// Options: 1x, 2x, 4x, 8x, 16x
+        /// Default: 8x [4]
+        /// </summary>
+        public GlobalIlluminationOption GlobalIllumination = GlobalIlluminationOption.Off;
         #endregion
 
         #region Methods
@@ -272,6 +279,13 @@ namespace CollapseLauncher.GameSettings.Genshin
 #endif
                         graphics.AnisotropicFiltering = (AnisotropicFilteringOption)setting.value;
                         break;
+
+                    case 19:
+#if DEBUG
+                        LogWriteLine($"Loaded Genshin Settings: Graphics - Global Illumination: {setting.value}", LogType.Debug, true);
+#endif
+                        graphics.GlobalIllumination = (GlobalIlluminationOption)setting.value;
+                        break;
                 }
             }
             return graphics;
@@ -296,7 +310,8 @@ namespace CollapseLauncher.GameSettings.Genshin
                 new GenshinKeyValuePair(13, (int)CrowdDensity),
                 new GenshinKeyValuePair(16, (int)CoOpTeammateEffects),
                 new GenshinKeyValuePair(15, (int)SubsurfaceScattering),
-                new GenshinKeyValuePair(17, (int)AnisotropicFiltering)
+                new GenshinKeyValuePair(17, (int)AnisotropicFiltering),
+                new GenshinKeyValuePair(19, (int)GlobalIllumination)
                 };
 
             JsonSerializerOptions options = new JsonSerializerOptions()

--- a/CollapseLauncher/Classes/GameManagement/GameVersion/BaseClass/GameVersionBase.cs
+++ b/CollapseLauncher/Classes/GameManagement/GameVersion/BaseClass/GameVersionBase.cs
@@ -311,11 +311,8 @@ namespace CollapseLauncher.GameVersioning
             return false;
         }
 
-        private bool IsDiskPartitionExist(string path)
-        {
-            DriveInfo info = new DriveInfo(Path.GetPathRoot(path));
-            return info.IsReady;
-        }
+        private bool IsDiskPartitionExist(string path) =>
+            string.IsNullOrEmpty(path) || string.IsNullOrEmpty(Path.GetPathRoot(path)) ? false : new DriveInfo(Path.GetPathRoot(path)).IsReady;
 
         private void SaveGameIni(string filePath, in IniFile INI)
         {

--- a/CollapseLauncher/Classes/InstallManagement/BaseClass/InstallManagerBase.cs
+++ b/CollapseLauncher/Classes/InstallManagement/BaseClass/InstallManagerBase.cs
@@ -630,6 +630,8 @@ namespace CollapseLauncher.InstallManager.Base
             {
                 LogWriteLine($"Failed while uninstalling game: {_gameVersionManager.GameType} - region: {_gameVersionManager.GamePreset.ZoneName}\r\n{ex}", LogType.Error, true);
             }
+
+            _gameVersionManager.UpdateGamePath("", true);
             _gameVersionManager.Reinitialize();
             return true;
         }

--- a/CollapseLauncher/Classes/InstallManagement/BaseClass/InstallManagerBase.cs
+++ b/CollapseLauncher/Classes/InstallManagement/BaseClass/InstallManagerBase.cs
@@ -535,13 +535,14 @@ namespace CollapseLauncher.InstallManager.Base
                             // Delete directories inside gameDataFolderName that is not included in foldersToKeepInData
                             if (File.GetAttributes(folderGameData).HasFlag(FileAttributes.Directory))
                             {
+                                TryUnassignReadOnlyFiles(folderGameData);
                                 Directory.Delete(folderGameData, true);
                                 LogWriteLine($"Deleted folder: {folderGameData}", LogType.Default, true);
                             }
                             // Delete files inside gameDataFolderName that is not included in foldersToKeepInData
                             else
                             {
-                                File.Delete(folderGameData);
+                                TryDeleteReadOnlyFile(folderGameData);
                                 LogWriteLine($"Deleted file: {folderGameData}", LogType.Default, true);
                             }
                             continue;
@@ -583,15 +584,8 @@ namespace CollapseLauncher.InstallManager.Base
                     if (UninstallProperty.filesToDelete.Length != 0 && UninstallProperty.filesToDelete.Contains(Path.GetFileName(fileNames)) ||
                         UninstallProperty.filesToDelete.Length != 0 && UninstallProperty.filesToDelete.Any(pattern => Regex.IsMatch(Path.GetFileName(fileNames), pattern, RegexOptions.Compiled | RegexOptions.NonBacktracking)))
                     {
-                        try
-                        {
-                            File.Delete(fileNames);
-                            LogWriteLine($"Deleted {fileNames}", LogType.Default, true);
-                        }
-                        catch (Exception ex)
-                        {
-                            LogWriteLine($"An error occurred while deleting file {fileNames}\r\n{ex}", LogType.Error, true);
-                        }
+                        TryDeleteReadOnlyFile(fileNames);
+                        LogWriteLine($"Deleted {fileNames}", LogType.Default, true);
                         continue;
                     }
                 }

--- a/CollapseLauncher/Classes/Interfaces/Class/ProgressBase.cs
+++ b/CollapseLauncher/Classes/Interfaces/Class/ProgressBase.cs
@@ -148,6 +148,31 @@ namespace CollapseLauncher.Interfaces
         #endregion
 
         #region BaseTools
+        protected void TryUnassignReadOnlyFiles(string path)
+        {
+            // Iterate every files and set the read-only flag to false
+            foreach (string file in Directory.EnumerateFiles(path, "*", SearchOption.AllDirectories))
+            {
+                FileInfo fileInfo = new FileInfo(file);
+                if (fileInfo.IsReadOnly)
+                    fileInfo.IsReadOnly = false;
+            }
+        }
+
+        protected void TryDeleteReadOnlyFile(string path)
+        {
+            try
+            {
+                FileInfo file = new FileInfo(path);
+                file.IsReadOnly = false;
+                file.Delete();
+            }
+            catch (Exception ex)
+            {
+                LogWriteLine($"Failed to delete file: {path}\r\n{ex}", LogType.Error, true);
+            }
+        }
+
         protected void MoveFolderContent(string SourcePath, string DestPath)
         {
             // Get the source folder path length + 1

--- a/CollapseLauncher/Classes/RepairManagement/Genshin/Check.cs
+++ b/CollapseLauncher/Classes/RepairManagement/Genshin/Check.cs
@@ -278,18 +278,5 @@ namespace CollapseLauncher
             }
         }
         #endregion
-
-        #region Tools
-        private void TryUnassignReadOnlyFiles()
-        {
-            // Iterate every files and set the read-only flag to false
-            foreach (string file in Directory.EnumerateFiles(_gamePath, "*", SearchOption.AllDirectories))
-            {
-                FileInfo fileInfo = new FileInfo(file);
-                if (fileInfo.IsReadOnly)
-                    fileInfo.IsReadOnly = false;
-            }
-        }
-        #endregion
     }
 }

--- a/CollapseLauncher/Classes/RepairManagement/Genshin/Fetch.cs
+++ b/CollapseLauncher/Classes/RepairManagement/Genshin/Fetch.cs
@@ -376,20 +376,6 @@ namespace CollapseLauncher
             _progressTotalCount = assetIndex.Count;
         }
 
-        private void TryDeleteReadOnlyFile(string path)
-        {
-            try
-            {
-                FileInfo file = new FileInfo(path);
-                file.IsReadOnly = false;
-                file.Delete();
-            }
-            catch (Exception ex)
-            {
-                LogWriteLine($"Failed to delete file: {path}\r\n{ex}", LogType.Error, true);
-            }
-        }
-
         private void EnumerateManifestToAssetIndex(string path, string filter, List<PkgVersionProperties> assetIndex, Dictionary<string, PkgVersionProperties> hashtable, string parentPath = "", string acceptedExtension = "", string parentURL = "")
         {
             // Iterate files inside the desired path based on filter.

--- a/CollapseLauncher/Classes/RepairManagement/Genshin/GenshinRepair.cs
+++ b/CollapseLauncher/Classes/RepairManagement/Genshin/GenshinRepair.cs
@@ -65,7 +65,7 @@ namespace CollapseLauncher
             _assetIndex.Clear();
 
             // Step 1: Ensure that every files are not read-only
-            TryUnassignReadOnlyFiles();
+            TryUnassignReadOnlyFiles(_gamePath);
 
             // Step 2: Fetch asset index
             _assetIndex = await Fetch(_assetIndex, _token.Token);

--- a/CollapseLauncher/CollapseLauncher.csproj
+++ b/CollapseLauncher/CollapseLauncher.csproj
@@ -23,7 +23,7 @@
     <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
 	</PropertyGroup>
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-		<DefineConstants>DISABLE_XAML_GENERATED_MAIN;PREVIEW;DISABLETRANSPARENT;DISABLEMOVEMIGRATE;SIMULATEAPPLYPRELOAD</DefineConstants>
+		<DefineConstants>DISABLE_XAML_GENERATED_MAIN;PREVIEW;DISABLETRANSPARENT;DISABLEMOVEMIGRATE;SIMULATEAPPLYPRELOAD;DUMPGIJSON</DefineConstants>
 	</PropertyGroup>
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
 		<DefineConstants>DISABLE_XAML_GENERATED_MAIN;PREVIEW;DISABLETRANSPARENT;DISABLEMOVEMIGRATE</DefineConstants>

--- a/CollapseLauncher/XAMLs/MainApp/Pages/Dialogs/SimpleDialogs.cs
+++ b/CollapseLauncher/XAMLs/MainApp/Pages/Dialogs/SimpleDialogs.cs
@@ -72,7 +72,7 @@ namespace CollapseLauncher.Dialogs
                     Lang._Dialogs.LocateExePathTitle,
                     Lang._Dialogs.LocateExePathSubtitle,
                     Content,
-                    null,
+                    Lang._Misc.Cancel,
                     Lang._Misc.LocateExecutable,
                     Lang._Misc.OpenDownloadPage
                 );

--- a/CollapseLauncher/XAMLs/MainApp/Pages/GenshinGameSettingsPage.Ext.cs
+++ b/CollapseLauncher/XAMLs/MainApp/Pages/GenshinGameSettingsPage.Ext.cs
@@ -211,7 +211,10 @@ namespace CollapseLauncher.Pages
                     VolumetricFogToggle.IsChecked = false;
                     VolumetricFogToggle.IsEnabled = false;
                 }
-                else VolumetricFogToggle.IsEnabled = true;
+                else 
+                {
+                    VolumetricFogToggle.IsEnabled = true; 
+                }
 
                 return curValue;
             }
@@ -222,7 +225,10 @@ namespace CollapseLauncher.Pages
                     VolumetricFogToggle.IsChecked = false;
                     VolumetricFogToggle.IsEnabled = false;
                 }
-                else VolumetricFogToggle.IsEnabled = true;
+                else 
+                {
+                    VolumetricFogToggle.IsEnabled = true; 
+                }
 
                 Settings.SettingsGeneralData.graphicsData.ShadowQuality = (ShadowQualityOption)(value + 1);
             } 

--- a/CollapseLauncher/XAMLs/MainApp/Pages/GenshinGameSettingsPage.Ext.cs
+++ b/CollapseLauncher/XAMLs/MainApp/Pages/GenshinGameSettingsPage.Ext.cs
@@ -264,6 +264,12 @@ namespace CollapseLauncher.Pages
             get => (bool)Settings.SettingsGeneralData.disableTeamPageBackgroundSwitch;
             set => Settings.SettingsGeneralData.disableTeamPageBackgroundSwitch = value;
         }
+
+        public int GlobalIllumination
+        {
+            get => (int)Settings.SettingsGeneralData.graphicsData.GlobalIllumination - 1;
+            set => Settings.SettingsGeneralData.graphicsData.GlobalIllumination = (GlobalIlluminationOption)(value + 1);
+        }
         #endregion
 
         #region Audio

--- a/CollapseLauncher/XAMLs/MainApp/Pages/GenshinGameSettingsPage.Ext.cs
+++ b/CollapseLauncher/XAMLs/MainApp/Pages/GenshinGameSettingsPage.Ext.cs
@@ -288,10 +288,10 @@ namespace CollapseLauncher.Pages
             set => Settings.SettingsGeneralData.graphicsData.Antialiasing = (AntialiasingOption)(value + 1);
         }
 
-        public bool DisableTeamPageBackground
+        public bool TeamPageBackground
         {
-            get => (bool)Settings.SettingsGeneralData.disableTeamPageBackgroundSwitch;
-            set => Settings.SettingsGeneralData.disableTeamPageBackgroundSwitch = value;
+            get => (bool)!Settings.SettingsGeneralData.disableTeamPageBackgroundSwitch;
+            set => Settings.SettingsGeneralData.disableTeamPageBackgroundSwitch = !value;
         }
 
         public int GlobalIllumination

--- a/CollapseLauncher/XAMLs/MainApp/Pages/GenshinGameSettingsPage.Ext.cs
+++ b/CollapseLauncher/XAMLs/MainApp/Pages/GenshinGameSettingsPage.Ext.cs
@@ -201,8 +201,31 @@ namespace CollapseLauncher.Pages
 
         public int ShadowQuality
         {
-            get => (int)Settings.SettingsGeneralData.graphicsData.ShadowQuality - 1;
-            set => Settings.SettingsGeneralData.graphicsData.ShadowQuality = (ShadowQualityOption)(value + 1);
+            get
+            {
+                int curValue = (int)Settings.SettingsGeneralData.graphicsData.ShadowQuality - 1;
+
+                // Disable Volumetric Fog when ShadowQuality is not Medium or higher
+                if (curValue < 2)
+                {
+                    VolumetricFogToggle.IsChecked = false;
+                    VolumetricFogToggle.IsEnabled = false;
+                }
+                else VolumetricFogToggle.IsEnabled = true;
+
+                return curValue;
+            }
+            set
+            {
+                if (value < 2)
+                {
+                    VolumetricFogToggle.IsChecked = false;
+                    VolumetricFogToggle.IsEnabled = false;
+                }
+                else VolumetricFogToggle.IsEnabled = true;
+
+                Settings.SettingsGeneralData.graphicsData.ShadowQuality = (ShadowQualityOption)(value + 1);
+            } 
         }
 
         public int VisualEffects

--- a/CollapseLauncher/XAMLs/MainApp/Pages/GenshinGameSettingsPage.Ext.cs
+++ b/CollapseLauncher/XAMLs/MainApp/Pages/GenshinGameSettingsPage.Ext.cs
@@ -258,6 +258,12 @@ namespace CollapseLauncher.Pages
             get => (int)Settings.SettingsGeneralData.graphicsData.Antialiasing - 1;
             set => Settings.SettingsGeneralData.graphicsData.Antialiasing = (AntialiasingOption)(value + 1);
         }
+
+        public bool DisableTeamPageBackground
+        {
+            get => (bool)Settings.SettingsGeneralData.disableTeamPageBackgroundSwitch;
+            set => Settings.SettingsGeneralData.disableTeamPageBackgroundSwitch = value;
+        }
         #endregion
 
         #region Audio

--- a/CollapseLauncher/XAMLs/MainApp/Pages/GenshinGameSettingsPage.xaml
+++ b/CollapseLauncher/XAMLs/MainApp/Pages/GenshinGameSettingsPage.xaml
@@ -210,6 +210,15 @@
                                             <ComboBoxItem Content="{x:Bind helper:Locale.Lang._GenshinGameSettingsPage.SpecEnabled}"/>
                                         </ComboBox>
                                     </StackPanel>
+                                    <StackPanel Grid.Column="2">
+                                        <TextBlock Text="{x:Bind helper:Locale.Lang._GenshinGameSettingsPage.Graphics_GlobalIllumination}" Style="{ThemeResource BodyStrongTextBlockStyle}" Margin="0,8,0,8"/>
+                                        <ComboBox x:Name="GlobalIlluminationSelector" Margin="0,0,0,8" Width="128" CornerRadius="14" SelectedIndex="{x:Bind GlobalIllumination, Mode=TwoWay}">
+                                            <ComboBoxItem Content="{x:Bind helper:Locale.Lang._GenshinGameSettingsPage.SpecDisabled}"/>
+                                            <ComboBoxItem Content="{x:Bind helper:Locale.Lang._GenshinGameSettingsPage.SpecMedium}"/>
+                                            <ComboBoxItem Content="{x:Bind helper:Locale.Lang._GenshinGameSettingsPage.SpecHigh}"/>
+                                            <ComboBoxItem Content="{x:Bind helper:Locale.Lang._GenshinGameSettingsPage.SpecExtreme}"/>
+                                        </ComboBox>
+                                    </StackPanel>
                                 </Grid>
                             </StackPanel>
                             <StackPanel Margin="0,8,0,8">

--- a/CollapseLauncher/XAMLs/MainApp/Pages/GenshinGameSettingsPage.xaml
+++ b/CollapseLauncher/XAMLs/MainApp/Pages/GenshinGameSettingsPage.xaml
@@ -253,10 +253,9 @@
                                             <!--
                                             A workaround for the tooltip not appearing when the checkbox is disabled.
                                             -->
+                                            <Border x:Name="VolumetricFogTooltipEnforcer" Background="Transparent" ToolTipService.ToolTip="{x:Bind helper:Locale.Lang._GenshinGameSettingsPage.Graphics_VolFogs_ToolTip}" Visibility="{x:Bind VolumetricFogToggle.IsEnabled, Converter={StaticResource BooleanToVisibilityConverter}}"/>
                                             <CheckBox x:Name="VolumetricFogToggle" Content="{x:Bind helper:Locale.Lang._GenshinGameSettingsPage.Graphics_VolFogs}" HorizontalAlignment="Left" VerticalAlignment="Center" IsChecked="{x:Bind VolumetricFog, Mode=TwoWay}">
                                             </CheckBox>
-                                            <Border x:Name="VolumetricFogTooltipEnforcer" Background="Transparent" ToolTipService.ToolTip="{x:Bind helper:Locale.Lang._GenshinGameSettingsPage.Graphics_VolFogs_ToolTip}" Visibility="{x:Bind VolumetricFogToggle.IsEnabled, Converter={StaticResource BooleanToVisibilityConverter}}">
-                                            </Border>
                                         </Grid>
                                     </StackPanel>
                                     <StackPanel Grid.Column="1">

--- a/CollapseLauncher/XAMLs/MainApp/Pages/GenshinGameSettingsPage.xaml
+++ b/CollapseLauncher/XAMLs/MainApp/Pages/GenshinGameSettingsPage.xaml
@@ -17,7 +17,7 @@
         <ThemeShadow x:Name="SharedShadow"/>
         <conv:InverseBooleanConverter x:Key="BooleanInverse"/>
         <f:DecimalFormatter x:Key="DecimalFormatter" SignificantDigits="5"/>
-        <conv:BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter"/>
+        <conv:BooleanVisibilityConverter x:Key="BooleanVisibilityConverter"/>
     </Page.Resources>
     <Grid>
         <Grid x:Name="PageContent">
@@ -253,7 +253,7 @@
                                             <!--
                                             A workaround for the tooltip not appearing when the checkbox is disabled.
                                             -->
-                                            <Border x:Name="VolumetricFogTooltipEnforcer" Background="Transparent" ToolTipService.ToolTip="{x:Bind helper:Locale.Lang._GenshinGameSettingsPage.Graphics_VolFogs_ToolTip}" Visibility="{x:Bind VolumetricFogToggle.IsEnabled, Converter={StaticResource BooleanToVisibilityConverter}}"/>
+                                            <Border x:Name="VolumetricFogTooltipEnforcer" Background="Transparent" ToolTipService.ToolTip="{x:Bind helper:Locale.Lang._GenshinGameSettingsPage.Graphics_VolFogs_ToolTip}" Visibility="{x:Bind VolumetricFogToggle.IsEnabled, Converter={StaticResource BooleanVisibilityConverter}}"/>
                                             <CheckBox x:Name="VolumetricFogToggle" Content="{x:Bind helper:Locale.Lang._GenshinGameSettingsPage.Graphics_VolFogs}" HorizontalAlignment="Left" VerticalAlignment="Center" IsChecked="{x:Bind VolumetricFog, Mode=TwoWay}">
                                             </CheckBox>
                                         </Grid>

--- a/CollapseLauncher/XAMLs/MainApp/Pages/GenshinGameSettingsPage.xaml
+++ b/CollapseLauncher/XAMLs/MainApp/Pages/GenshinGameSettingsPage.xaml
@@ -230,6 +230,19 @@
                                     </StackPanel>
                                 </Grid>
                             </StackPanel>
+                            <StackPanel Margin="0,8,0,8">
+                                <Grid>
+                                    <!--
+                                    Unused for now
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition/>
+                                    </Grid.ColumnDefinitions>
+                                    -->
+                                    <StackPanel Grid.Column="0">
+                                        <CheckBox x:Name="TeamPageBackgroundDisableToggle" Content="{x:Bind helper:Locale.Lang._GenshinGameSettingsPage.Graphics_DisableTeamPageBackground}" HorizontalAlignment="Left" VerticalAlignment="Center" IsChecked="{x:Bind DisableTeamPageBackground, Mode=TwoWay}"/>
+                                    </StackPanel>
+                                </Grid>
+                            </StackPanel>
                         </StackPanel>
                     </Grid>
                     <MenuFlyoutSeparator Margin="0,4,0,8"/>

--- a/CollapseLauncher/XAMLs/MainApp/Pages/GenshinGameSettingsPage.xaml
+++ b/CollapseLauncher/XAMLs/MainApp/Pages/GenshinGameSettingsPage.xaml
@@ -389,8 +389,8 @@
                                 </Grid.ColumnDefinitions>
                                 <StackPanel Grid.Column="0" x:Name="LangSettingLeft">
                                     <StackPanel>
-                                        <TextBlock Text="{x:Bind helper:Locale.Lang._GenshinGameSettingsPage.LanguageAudio}" Style="{ThemeResource BodyStrongTextBlockStyle}" Margin="16,0,0,8"/>
-                                        <ComboBox x:Name="AudioLangSelector" Margin="16,0,0,16" Width="128" CornerRadius="14" SelectedIndex="{x:Bind AudioLang, Mode=TwoWay}">
+                                        <TextBlock Text="{x:Bind helper:Locale.Lang._GenshinGameSettingsPage.LanguageAudio}" Style="{ThemeResource BodyStrongTextBlockStyle}" Margin="0,0,0,8"/>
+                                        <ComboBox x:Name="AudioLangSelector" Margin="0,0,0,16" Width="128" CornerRadius="14" SelectedIndex="{x:Bind AudioLang, Mode=TwoWay}">
                                             <ComboBoxItem Content="{x:Bind helper:Locale.Lang._GenshinGameSettingsPage.VO_cn}"/>
                                             <ComboBoxItem Content="{x:Bind helper:Locale.Lang._GenshinGameSettingsPage.VO_en}"/>
                                             <ComboBoxItem Content="{x:Bind helper:Locale.Lang._GenshinGameSettingsPage.VO_jp}"/>

--- a/CollapseLauncher/XAMLs/MainApp/Pages/GenshinGameSettingsPage.xaml
+++ b/CollapseLauncher/XAMLs/MainApp/Pages/GenshinGameSettingsPage.xaml
@@ -276,7 +276,7 @@
                                     </Grid.ColumnDefinitions>
                                     -->
                                     <StackPanel Grid.Column="0">
-                                        <CheckBox x:Name="TeamPageBackgroundDisableToggle" Content="{x:Bind helper:Locale.Lang._GenshinGameSettingsPage.Graphics_DisableTeamPageBackground}" HorizontalAlignment="Left" VerticalAlignment="Center" IsChecked="{x:Bind DisableTeamPageBackground, Mode=TwoWay}"/>
+                                        <CheckBox x:Name="TeamPageBackgroundToggle" Content="{x:Bind helper:Locale.Lang._GenshinGameSettingsPage.Graphics_TeamPageBackground}" HorizontalAlignment="Left" VerticalAlignment="Center" IsChecked="{x:Bind TeamPageBackground, Mode=TwoWay}"/>
                                     </StackPanel>
                                 </Grid>
                             </StackPanel>

--- a/CollapseLauncher/XAMLs/MainApp/Pages/GenshinGameSettingsPage.xaml
+++ b/CollapseLauncher/XAMLs/MainApp/Pages/GenshinGameSettingsPage.xaml
@@ -17,6 +17,7 @@
         <ThemeShadow x:Name="SharedShadow"/>
         <conv:InverseBooleanConverter x:Key="BooleanInverse"/>
         <f:DecimalFormatter x:Key="DecimalFormatter" SignificantDigits="5"/>
+        <conv:BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter"/>
     </Page.Resources>
     <Grid>
         <Grid x:Name="PageContent">
@@ -212,12 +213,31 @@
                                     </StackPanel>
                                     <StackPanel Grid.Column="2">
                                         <TextBlock Text="{x:Bind helper:Locale.Lang._GenshinGameSettingsPage.Graphics_GlobalIllumination}" Style="{ThemeResource BodyStrongTextBlockStyle}" Margin="0,8,0,8"/>
-                                        <ComboBox x:Name="GlobalIlluminationSelector" Margin="0,0,0,8" Width="128" CornerRadius="14" SelectedIndex="{x:Bind GlobalIllumination, Mode=TwoWay}">
-                                            <ComboBoxItem Content="{x:Bind helper:Locale.Lang._GenshinGameSettingsPage.SpecDisabled}"/>
-                                            <ComboBoxItem Content="{x:Bind helper:Locale.Lang._GenshinGameSettingsPage.SpecMedium}"/>
-                                            <ComboBoxItem Content="{x:Bind helper:Locale.Lang._GenshinGameSettingsPage.SpecHigh}"/>
-                                            <ComboBoxItem Content="{x:Bind helper:Locale.Lang._GenshinGameSettingsPage.SpecExtreme}"/>
-                                        </ComboBox>
+                                        <StackPanel Orientation="Horizontal">
+                                            <ComboBox x:Name="GlobalIlluminationSelector" Margin="0,0,0,8" Width="128" CornerRadius="14" SelectedIndex="{x:Bind GlobalIllumination, Mode=TwoWay}">
+                                                <ComboBoxItem Content="{x:Bind helper:Locale.Lang._GenshinGameSettingsPage.SpecDisabled}"/>
+                                                <ComboBoxItem Content="{x:Bind helper:Locale.Lang._GenshinGameSettingsPage.SpecMedium}"/>
+                                                <ComboBoxItem Content="{x:Bind helper:Locale.Lang._GenshinGameSettingsPage.SpecHigh}"/>
+                                                <ComboBoxItem Content="{x:Bind helper:Locale.Lang._GenshinGameSettingsPage.SpecExtreme}"/>
+                                            </ComboBox>
+                                            <Button Margin="4,-10,0,0" HorizontalAlignment="Center" Height="30" Width="15" CornerRadius="4" Padding="0">
+                                                <Button.Content>
+                                                    <FontIcon FontFamily="{ThemeResource FontAwesome}" Glyph="&#x3f;" FontSize="10"/>
+                                                </Button.Content>
+                                                <Button.Flyout>
+                                                    <Flyout>
+                                                        <StackPanel>
+                                                            <TextBlock Style="{ThemeResource BaseTextBlockStyle}" TextAlignment="Center">
+                                                                <Run Text="{x:Bind helper:Locale.Lang._GenshinGameSettingsPage.Graphics_GlobalIllumination_Help1}"/><LineBreak/>
+                                                                <Hyperlink NavigateUri="https://genshin.hoyoverse.com/en/news/detail/112690#:~:text=Minimum%20Specifications%20for%20Global%20Illumination">
+                                                                    <Run Text="{x:Bind helper:Locale.Lang._GenshinGameSettingsPage.Graphics_GlobalIllumination_Help2}"/>
+                                                                </Hyperlink>
+                                                            </TextBlock>
+                                                        </StackPanel>
+                                                    </Flyout>
+                                                </Button.Flyout>
+                                            </Button>
+                                        </StackPanel>
                                     </StackPanel>
                                 </Grid>
                             </StackPanel>
@@ -229,7 +249,15 @@
                                         <ColumnDefinition/>
                                     </Grid.ColumnDefinitions>
                                     <StackPanel Grid.Column="0">
-                                        <CheckBox x:Name="VolumetricFogToggle" Content="{x:Bind helper:Locale.Lang._GenshinGameSettingsPage.Graphics_VolFogs}" HorizontalAlignment="Left" VerticalAlignment="Center" IsChecked="{x:Bind VolumetricFog, Mode=TwoWay}"/>
+                                        <Grid>
+                                            <!--
+                                            A workaround for the tooltip not appearing when the checkbox is disabled.
+                                            -->
+                                            <CheckBox x:Name="VolumetricFogToggle" Content="{x:Bind helper:Locale.Lang._GenshinGameSettingsPage.Graphics_VolFogs}" HorizontalAlignment="Left" VerticalAlignment="Center" IsChecked="{x:Bind VolumetricFog, Mode=TwoWay}">
+                                            </CheckBox>
+                                            <Border x:Name="VolumetricFogTooltipEnforcer" Background="Transparent" ToolTipService.ToolTip="{x:Bind helper:Locale.Lang._GenshinGameSettingsPage.Graphics_VolFogs_ToolTip}" Visibility="{x:Bind VolumetricFogToggle.IsEnabled, Converter={StaticResource BooleanToVisibilityConverter}}">
+                                            </Border>
+                                        </Grid>
                                     </StackPanel>
                                     <StackPanel Grid.Column="1">
                                         <CheckBox x:Name="ReflectionsToggle" Content="{x:Bind helper:Locale.Lang._GenshinGameSettingsPage.Graphics_ReflectionQuality}" HorizontalAlignment="Left" VerticalAlignment="Center" IsChecked="{x:Bind Reflections, Mode=TwoWay}"/>
@@ -239,7 +267,7 @@
                                     </StackPanel>
                                 </Grid>
                             </StackPanel>
-                            <StackPanel Margin="0,8,0,8">
+                            <StackPanel Margin="0,0,0,8">
                                 <Grid>
                                     <!--
                                     Unused for now

--- a/CollapseLauncher/XAMLs/MainApp/Pages/HomePage.xaml.cs
+++ b/CollapseLauncher/XAMLs/MainApp/Pages/HomePage.xaml.cs
@@ -464,6 +464,9 @@ namespace CollapseLauncher.Pages
                         case ContentDialogResult.Secondary:
                             // If the main dialog is getting cancelled, then return false (as cancel and fallback to URL [if enabled]).
                             return false;
+                        case ContentDialogResult.None:
+                            // Return true when cancelled
+                            return true;
                     }
 
                     // If the file variable is not null anymore, then break from the loop and continue

--- a/CollapseLauncher/XAMLs/MainApp/ValueConverters.cs
+++ b/CollapseLauncher/XAMLs/MainApp/ValueConverters.cs
@@ -25,16 +25,4 @@ namespace CollapseLauncher.Pages
         public object Convert(object value, Type targetType, object parameter, string input) => (bool)value ? Visibility.Visible : Visibility.Collapsed;
         public object ConvertBack(object value, Type targetType, object parameter, string input) => new NotImplementedException();
     }
-
-    public class BooleanToVisibilityConverter : IValueConverter
-    {
-        public object Convert(object value, Type targetType, object parameter, string language)
-        {
-            return (value is bool && (bool)value) ? Visibility.Visible : Visibility.Collapsed;
-        }
-        public object ConvertBack(object value, Type targetType, object parameter, string language)
-        {
-            return value is Visibility && (Visibility)value == Visibility.Visible;
-        }
-    }
 }

--- a/CollapseLauncher/XAMLs/MainApp/ValueConverters.cs
+++ b/CollapseLauncher/XAMLs/MainApp/ValueConverters.cs
@@ -25,4 +25,16 @@ namespace CollapseLauncher.Pages
         public object Convert(object value, Type targetType, object parameter, string input) => (bool)value ? Visibility.Visible : Visibility.Collapsed;
         public object ConvertBack(object value, Type targetType, object parameter, string input) => new NotImplementedException();
     }
+
+    public class BooleanToVisibilityConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, string language)
+        {
+            return (value is bool && (bool)value) ? Visibility.Visible : Visibility.Collapsed;
+        }
+        public object ConvertBack(object value, Type targetType, object parameter, string language)
+        {
+            return value is Visibility && (Visibility)value == Visibility.Visible;
+        }
+    }
 }

--- a/Hi3Helper.Core/Lang/Locale/LangGenshinGameSettingsPage.cs
+++ b/Hi3Helper.Core/Lang/Locale/LangGenshinGameSettingsPage.cs
@@ -74,7 +74,7 @@
                 public string Graphics_SubsurfaceScattering { get; set; } = LangFallback?._GenshinGameSettingsPage.Graphics_SubsurfaceScattering;
                 public string Graphics_TeammateFX { get; set; } = LangFallback?._GenshinGameSettingsPage.Graphics_TeammateFX;
                 public string Graphics_AnisotropicFiltering { get; set; } = LangFallback?._GenshinGameSettingsPage.Graphics_AnisotropicFiltering;
-                public string Graphics_DisableTeamPageBackground { get; set; } = LangFallback?._GenshinGameSettingsPage.Graphics_DisableTeamPageBackground;
+                public string Graphics_TeamPageBackground { get; set; } = LangFallback?._GenshinGameSettingsPage.Graphics_TeamPageBackground;
                 public string Graphics_GlobalIllumination { get; set; } = LangFallback?._GenshinGameSettingsPage.Graphics_GlobalIllumination;
                 public string Graphics_GlobalIllumination_Help1 { get; set; } = LangFallback?._GenshinGameSettingsPage.Graphics_GlobalIllumination_Help1;
                 public string Graphics_GlobalIllumination_Help2 { get; set; } = LangFallback?._GenshinGameSettingsPage.Graphics_GlobalIllumination_Help2;

--- a/Hi3Helper.Core/Lang/Locale/LangGenshinGameSettingsPage.cs
+++ b/Hi3Helper.Core/Lang/Locale/LangGenshinGameSettingsPage.cs
@@ -73,6 +73,7 @@
                 public string Graphics_SubsurfaceScattering { get; set; } = LangFallback?._GenshinGameSettingsPage.Graphics_SubsurfaceScattering;
                 public string Graphics_TeammateFX { get; set; } = LangFallback?._GenshinGameSettingsPage.Graphics_TeammateFX;
                 public string Graphics_AnisotropicFiltering { get; set; } = LangFallback?._GenshinGameSettingsPage.Graphics_AnisotropicFiltering;
+                public string Graphics_DisableTeamPageBackground { get; set; } = LangFallback?._GenshinGameSettingsPage.Graphics_DisableTeamPageBackground;
                 #endregion
 
                 #region Specs

--- a/Hi3Helper.Core/Lang/Locale/LangGenshinGameSettingsPage.cs
+++ b/Hi3Helper.Core/Lang/Locale/LangGenshinGameSettingsPage.cs
@@ -74,6 +74,7 @@
                 public string Graphics_TeammateFX { get; set; } = LangFallback?._GenshinGameSettingsPage.Graphics_TeammateFX;
                 public string Graphics_AnisotropicFiltering { get; set; } = LangFallback?._GenshinGameSettingsPage.Graphics_AnisotropicFiltering;
                 public string Graphics_DisableTeamPageBackground { get; set; } = LangFallback?._GenshinGameSettingsPage.Graphics_DisableTeamPageBackground;
+                public string Graphics_GlobalIllumination { get; set; } = LangFallback?._GenshinGameSettingsPage.Graphics_GlobalIllumination;
                 #endregion
 
                 #region Specs
@@ -84,6 +85,7 @@
                 public string SpecMedium { get; set; } = LangFallback?._GenshinGameSettingsPage.SpecMedium;
                 public string SpecHigh { get; set; } = LangFallback?._GenshinGameSettingsPage.SpecHigh;
                 public string SpecVeryHigh { get; set; } = LangFallback?._GenshinGameSettingsPage.SpecVeryHigh;
+                public string SpecExtreme { get; set; } = LangFallback?._GenshinGameSettingsPage.SpecExtreme;
                 public string SpecPartiallyOff { get; set; } = LangFallback?._GenshinGameSettingsPage.SpecPartiallyOff;
                 #endregion
 

--- a/Hi3Helper.Core/Lang/Locale/LangGenshinGameSettingsPage.cs
+++ b/Hi3Helper.Core/Lang/Locale/LangGenshinGameSettingsPage.cs
@@ -66,6 +66,7 @@
                 public string Graphics_VSync { get; set; } = LangFallback?._GenshinGameSettingsPage.Graphics_VSync;
                 public string Graphics_AAMode { get; set; } = LangFallback?._GenshinGameSettingsPage.Graphics_AAMode;
                 public string Graphics_VolFogs { get; set; } = LangFallback?._GenshinGameSettingsPage.Graphics_VolFogs;
+                public string Graphics_VolFogs_ToolTip { get; set; } = LangFallback?._GenshinGameSettingsPage.Graphics_VolFogs_ToolTip;
                 public string Graphics_ReflectionQuality { get; set; } = LangFallback?._GenshinGameSettingsPage.Graphics_ReflectionQuality;
                 public string Graphics_MotionBlur { get; set; } = LangFallback?._GenshinGameSettingsPage.Graphics_MotionBlur;
                 public string Graphics_BloomQuality { get; set; } = LangFallback?._GenshinGameSettingsPage.Graphics_BloomQuality;
@@ -75,6 +76,8 @@
                 public string Graphics_AnisotropicFiltering { get; set; } = LangFallback?._GenshinGameSettingsPage.Graphics_AnisotropicFiltering;
                 public string Graphics_DisableTeamPageBackground { get; set; } = LangFallback?._GenshinGameSettingsPage.Graphics_DisableTeamPageBackground;
                 public string Graphics_GlobalIllumination { get; set; } = LangFallback?._GenshinGameSettingsPage.Graphics_GlobalIllumination;
+                public string Graphics_GlobalIllumination_Help1 { get; set; } = LangFallback?._GenshinGameSettingsPage.Graphics_GlobalIllumination_Help1;
+                public string Graphics_GlobalIllumination_Help2 { get; set; } = LangFallback?._GenshinGameSettingsPage.Graphics_GlobalIllumination_Help2;
                 #endregion
 
                 #region Specs

--- a/Hi3Helper.Core/Lang/en-us.json
+++ b/Hi3Helper.Core/Lang/en-us.json
@@ -821,7 +821,7 @@
     "Graphics_SubsurfaceScattering": "Subsurface Scattering",
     "Graphics_TeammateFX": "Teammate Effects",
     "Graphics_AnisotropicFiltering": "Anisotropic Filtering",
-    "Graphics_DisableTeamPageBackground": "Disable Team Page Background",
+    "Graphics_TeamPageBackground": "Regional Party Setup Background",
     "Graphics_GlobalIllumination": "Global Illumination",
     "Graphics_GlobalIllumination_Help1": "Only for supported hardware!",
     "Graphics_GlobalIllumination_Help2": "More information (en)",

--- a/Hi3Helper.Core/Lang/en-us.json
+++ b/Hi3Helper.Core/Lang/en-us.json
@@ -820,6 +820,7 @@
     "Graphics_SubsurfaceScattering": "Subsurface Scattering",
     "Graphics_TeammateFX": "Teammate Effects",
     "Graphics_AnisotropicFiltering": "Anisotropic Filtering",
+    "Graphics_DisableTeamPageBackground": "Disable Team Page Background",
 
     "Graphics_SpecPanel": "Global Graphics Settings",
     "SpecEnabled": "Enabled",

--- a/Hi3Helper.Core/Lang/en-us.json
+++ b/Hi3Helper.Core/Lang/en-us.json
@@ -821,6 +821,7 @@
     "Graphics_TeammateFX": "Teammate Effects",
     "Graphics_AnisotropicFiltering": "Anisotropic Filtering",
     "Graphics_DisableTeamPageBackground": "Disable Team Page Background",
+    "Graphics_GlobalIllumination": "Global Illumination",
 
     "Graphics_SpecPanel": "Global Graphics Settings",
     "SpecEnabled": "Enabled",
@@ -830,6 +831,7 @@
     "SpecMedium": "Medium",
     "SpecHigh": "High",
     "SpecVeryHigh": "Very High",
+    "SpecExtreme": "Extreme",
     "SpecPartiallyOff": "Partially Off",
 
     "ApplyBtn": "Apply Settings",

--- a/Hi3Helper.Core/Lang/en-us.json
+++ b/Hi3Helper.Core/Lang/en-us.json
@@ -813,6 +813,7 @@
     "Graphics_VSync": "VSync",
     "Graphics_AAMode": "Anti-Aliasing Mode",
     "Graphics_VolFogs": "Volumetric Fogs",
+    "Graphics_VolFogs_ToolTip": "Requires Shadow Quality to be set at Medium or higher!",
     "Graphics_ReflectionQuality": "Reflection",
     "Graphics_MotionBlur": "Motion Blur",
     "Graphics_BloomQuality": "Bloom",
@@ -822,6 +823,8 @@
     "Graphics_AnisotropicFiltering": "Anisotropic Filtering",
     "Graphics_DisableTeamPageBackground": "Disable Team Page Background",
     "Graphics_GlobalIllumination": "Global Illumination",
+    "Graphics_GlobalIllumination_Help1": "Only for supported hardware!",
+    "Graphics_GlobalIllumination_Help2": "More information (en)",
 
     "Graphics_SpecPanel": "Global Graphics Settings",
     "SpecEnabled": "Enabled",

--- a/Hi3Helper.Core/Lang/en-us.json
+++ b/Hi3Helper.Core/Lang/en-us.json
@@ -468,7 +468,7 @@
     "CDNDescription_Statically": "A mirror of the official (main) repository, provided by Statically. Use this if you're living in a place where GitHub is inaccessible.",
     "CDNDescription_jsDelivr": "jsDelivr uses multiple CDN providers like CloudFlare, Fastly and Quantil, resulting in the best possible uptime and performance.",
 
-    "LocateExecutable": "Locate Program Executable",
+    "LocateExecutable": "Locate Executable",
     "OpenDownloadPage": "Open Download Page",
 
     "DiscordRP_Play": "Playing",

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ Not only that, this launcher also has some advanced features for **Genshin Impac
       <td>:white_check_mark:</td>
       <td>:white_check_mark:</td>
       <td>:white_check_mark:</td>
-      <td>:x:</td>
+      <td>N/A</td>
       <td>:white_check_mark:</td>
       <td>N/A</td>
     </tr>
@@ -149,8 +149,8 @@ Not only that, this launcher also has some advanced features for **Genshin Impac
       <td>:white_check_mark:</td>
       <td>:white_check_mark:</td>
       <td>:white_check_mark:</td>
-      <td>:x:</td>
-      <td>:x:</td>
+      <td>:white_check_mark:</td>
+      <td>N/A</td>
       <td>:white_check_mark:</td>
       <td>N/A</td>
     </tr>
@@ -160,8 +160,8 @@ Not only that, this launcher also has some advanced features for **Genshin Impac
       <td>:white_check_mark:</td>
       <td>:white_check_mark:</td>
       <td>:white_check_mark:</td>
-      <td>:x:</td>
-      <td>:x:</td>
+      <td>:white_check_mark:</td>
+      <td>:white_check_mark:</td>
       <td>:white_check_mark:</td>
       <td>N/A</td>
     </tr>
@@ -170,8 +170,8 @@ Not only that, this launcher also has some advanced features for **Genshin Impac
       <td>:white_check_mark:</td>
       <td>:white_check_mark:</td>
       <td>:white_check_mark:</td>
-      <td>:x:</td>
-      <td>:x:</td>
+      <td>:white_check_mark:</td>
+      <td>:white_check_mark:</td>
       <td>:white_check_mark:</td>
       <td>N/A</td>
     </tr>


### PR DESCRIPTION
Following the update from GI 4.0
Changes:
- Item sorting is back to 3.7 version
- Adjusted mtr and url default values
- **New Settings:** DisableTeamPageBackground
- **New Settings:** Global Illumination
   > Note: This setting will be ignored on unsupported specs
- New debug logging: dumps the entire json to multiple lines now :FuHuaEyes:

TODO:
~~Check Global Illumination toggle location~~
```
Adds Global Illumination on PlayStation® and will automatically be in effect after the Version update.

Adds Global Illumination on PC devices with a Discrete Graphics Card with a VRAM of 4 GB or more. Travelers may enable it via Settings > Graphics.
```