### PR TITLE
Fix shadow and animation of social midia button

### DIFF
--- a/CollapseLauncher/XAMLs/MainApp/Pages/HomePage.xaml.cs
+++ b/CollapseLauncher/XAMLs/MainApp/Pages/HomePage.xaml.cs
@@ -24,6 +24,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Numerics;
 using System.Reflection;
 using System.Text;
 using System.Threading;
@@ -272,15 +273,19 @@ namespace CollapseLauncher.Pages
         #region SocMed Buttons
         private void FadeInSocMedButton(object sender, PointerRoutedEventArgs e)
         {
-            Storyboard sb = ((Button)sender).Resources["EnterStoryboard"] as Storyboard;
-            ((Button)sender).Translation += Shadow16;
+            Button btn = (Button)sender;
+            if (btn.Translation != Vector3.Zero || e.OriginalSource is Image) return;
+            Storyboard sb = btn.Resources["EnterStoryboard"] as Storyboard;
+            btn.Translation += Shadow16;
             sb.Begin();
         }
 
         private void FadeOutSocMedButton(object sender, PointerRoutedEventArgs e)
         {
-            Storyboard sb = ((Button)sender).Resources["ExitStoryboard"] as Storyboard;
-            ((Button)sender).Translation -= Shadow16;
+            Button btn = (Button)sender;
+            if (btn.Translation == Vector3.Zero || e.OriginalSource is Image) return;
+            Storyboard sb = btn.Resources["ExitStoryboard"] as Storyboard;
+            btn.Translation -= Shadow16;
             sb.Begin();
         }
 


### PR DESCRIPTION
This PR fixes the following two issues:
1. Animation is triggered unexpectedly when pointer enters shadow of tooltip. This is because the button lost and regain the pointer caused by a `Image` inside `ImageEx`.
2. The shadow won't disappear after the button gain pointer from tooltip. Function `FadeInSocMedButton` got called twice.

![issue](https://github.com/neon-nyan/Collapse/assets/31368738/a1ce305b-dafa-4ddd-871d-584331771594)
