### PR TITLE
Add links to social media popup panel

### DIFF
--- a/CollapseLauncher/Classes/RegionManagement/RegionManagement.cs
+++ b/CollapseLauncher/Classes/RegionManagement/RegionManagement.cs
@@ -278,11 +278,25 @@ namespace CollapseLauncher
             regionNewsProp.sideMenuPanel = new List<MenuPanelProp>();
             foreach (RegionSocMedProp item in regionBackgroundProp.data.icon)
             {
-                string url = item.url;
-                if (string.IsNullOrEmpty(url) && item.links.Count != 0 && !string.IsNullOrEmpty(item.links[0].url))
+                // Default: links
+                // Fallback: url/title + other_links
+                IList<LinkProp> links = item.links;
+                if (links == null && !string.IsNullOrEmpty(item.url))
                 {
-                    url = item.links[0].url;
+                    links = new List<LinkProp>
+                    {
+                        new() { title = item.title, url = item.url }
+                    };
+                    links = links.Concat(item.other_links).ToList();
                 }
+
+                string url = item.icon_link;
+                if (string.IsNullOrEmpty(url) && links.Any() && !string.IsNullOrEmpty(links[0].url))
+                {
+                    url = links[0].url;
+                }
+
+                // Add missing *key* parameter to QQ group link
                 if (!string.IsNullOrEmpty(url) && !string.IsNullOrEmpty(Preset.LauncherSpriteURL))
                 {
                     if (new Uri(url).Segments.Last() == "qq")
@@ -296,19 +310,13 @@ namespace CollapseLauncher
                     }
                 }
 
-                string desc = item.url;
+                string desc = url;
                 if (!Preset.IsHideSocMedDesc)
                 {
-                    if (!string.IsNullOrEmpty(item.title))
+                    desc = item.tittle;
+                    if (string.IsNullOrEmpty(desc) && links.Any() && !string.IsNullOrEmpty(links[0].title))
                     {
-                        desc = item.title;
-                    }
-                    else
-                    {
-                        if (item.links.Count != 0 && !string.IsNullOrEmpty(item.links[0].title))
-                        {
-                            desc = item.links[0].title;
-                        }
+                        desc = links[0].title;
                     }
                 }
 
@@ -319,7 +327,8 @@ namespace CollapseLauncher
                     IconHover = item.img_hover,
                     QR = string.IsNullOrEmpty(item.qr_img) ? null : item.qr_img,
                     QR_Description = string.IsNullOrEmpty(item.qr_desc) ? null : item.qr_desc,
-                    Description = desc
+                    Description = desc,
+                    Links = links
                 });
             }
         }

--- a/CollapseLauncher/XAMLs/MainApp/Pages/HomePage.xaml
+++ b/CollapseLauncher/XAMLs/MainApp/Pages/HomePage.xaml
@@ -249,23 +249,51 @@
                                 </ItemsControl.Transitions>
                                 <ItemsControl.ItemTemplate>
                                     <DataTemplate>
-                                        <Button Width="48px" Height="48px" Margin="8,4" Padding="8" CornerRadius="8" Style="{ThemeResource EllipsisButtonRevealStyle}"
+                                        <Button x:Name="SocMedButton" Width="48px" Height="48px" Margin="8,4" Padding="8" CornerRadius="8" Style="{ThemeResource EllipsisButtonRevealStyle}"
                                              PointerEntered="FadeInSocMedButton" PointerExited="FadeOutSocMedButton" Tag="{Binding URL}" Click="OpenSocMedLink"
-                                             Shadow="{ThemeResource SharedShadow}">
+                                             Shadow="{ThemeResource SharedShadow}" FlyoutBase.AttachedFlyout="{Binding ElementName=SocMedFlyout}">
                                             <ToolTipService.ToolTip>
-                                                <StackPanel>
-                                                    <StackPanel Margin="8,8,8,0" Visibility="{Binding IsQRExist, Converter={ThemeResource BooleanToVisibilityConverter}}">
-                                                        <Grid Background="White" Margin="0,0,0,8" CornerRadius="5">
-                                                            <Image Source="{Binding QR}" Width="160" HorizontalAlignment="Center"/>
-                                                        </Grid>
-                                                        <TextBlock Text="{Binding QR_Description}" HorizontalAlignment="Center" FontWeight="Bold" TextWrapping="Wrap"
-                                                               Visibility="{Binding IsQRDescriptionExist, Converter={ThemeResource BooleanToVisibilityConverter}}"/>
-                                                    </StackPanel>
-                                                    <TextBlock Text="{Binding Description}" HorizontalAlignment="Center" TextWrapping="Wrap"
-                                                               Visibility="{Binding IsDescriptionExist, Converter={ThemeResource BooleanToVisibilityConverter}}"/>
-                                                </StackPanel>
+                                                <ToolTip Visibility="Collapsed" Tag="{Binding ElementName=SocMedButton}" Opened="ShowSocMedFlyout"/>
                                             </ToolTipService.ToolTip>
                                             <Button.Resources>
+                                                <Flyout x:Name="SocMedFlyout" Placement="Left" OverlayInputPassThroughElement="{Binding ElementName=SocMedPanelScrollView}">
+                                                    <StackPanel PointerExited="HideSocMedFlyout" Tag="{Binding ElementName=SocMedFlyout}" Padding="10,6" Background="Transparent" Loaded="OnLoadedSocMedFlyout">
+                                                        <StackPanel Margin="8,8,8,0" Visibility="{Binding IsQRExist, Converter={ThemeResource BooleanToVisibilityConverter}}">
+                                                            <Grid Background="White" Margin="0,0,0,8" CornerRadius="5">
+                                                                <Image Source="{Binding QR}" Width="160" HorizontalAlignment="Center"/>
+                                                            </Grid>
+                                                            <TextBlock Text="{Binding QR_Description}" HorizontalAlignment="Center" FontWeight="Bold" TextWrapping="Wrap" Margin="0,0,0,4"
+                                                                       Visibility="{Binding IsQRDescriptionExist, Converter={ThemeResource BooleanToVisibilityConverter}}"/>
+                                                        </StackPanel>
+                                                        <StackPanel Visibility="{Binding ShowLinks, Converter={ThemeResource BooleanToVisibilityConverter}}">
+                                                            <ItemsControl ItemsSource="{Binding Links}">
+                                                                <ItemsControl.ItemTemplate>
+                                                                    <DataTemplate>
+                                                                        <Button Tag="{Binding url}" Click="OpenSocMedLink" HorizontalAlignment="Center">
+                                                                            <Button.Template>
+                                                                                <ControlTemplate>
+                                                                                    <TextBlock Text="{Binding title}" TextWrapping="Wrap" Margin="2,2" Foreground="{ThemeResource TextFillColorPrimary}"
+                                                                                        TextDecorations="Underline" PointerEntered="HyperLink_OnPointerEntered" PointerExited="HyperLink_OnPointerExited" Loaded="SetHandCursor"/>
+                                                                                </ControlTemplate>
+                                                                            </Button.Template>
+                                                                        </Button>
+                                                                    </DataTemplate>
+                                                                </ItemsControl.ItemTemplate>
+                                                            </ItemsControl>
+                                                        </StackPanel>
+                                                        <TextBlock Text="{Binding Description}" HorizontalAlignment="Center" TextWrapping="Wrap"
+                                                                       Visibility="{Binding ShowDescription, Converter={ThemeResource BooleanToVisibilityConverter}}"/>
+                                                    </StackPanel>
+                                                    <Flyout.FlyoutPresenterStyle>
+                                                        <Style TargetType="FlyoutPresenter">
+                                                            <Setter Property="Margin" Value="3,0,0,0"/>
+                                                            <Setter Property="CornerRadius" Value="5"/>
+                                                            <Setter Property="Padding" Value="0"/>
+                                                            <Setter Property="MinHeight" Value="0"/>
+                                                            <Setter Property="MinWidth" Value="0"/>
+                                                        </Style>
+                                                    </Flyout.FlyoutPresenterStyle>
+                                                </Flyout>
                                                 <Storyboard x:Name="EnterStoryboard">
                                                     <DoubleAnimation Storyboard.TargetName="Icon" Storyboard.TargetProperty="Opacity" From="1" To="0" Duration="0:0:0.1"/>
                                                     <DoubleAnimation Storyboard.TargetName="IconHover" Storyboard.TargetProperty="Opacity" From="0" To="1" Duration="0:0:0.1"/>

--- a/CollapseLauncher/XAMLs/MainApp/Pages/HomePage.xaml.cs
+++ b/CollapseLauncher/XAMLs/MainApp/Pages/HomePage.xaml.cs
@@ -29,6 +29,7 @@ using System.Reflection;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Windows.Foundation;
 using Windows.UI.Text;
 using static CollapseLauncher.Dialogs.SimpleDialogs;
 using static CollapseLauncher.InnerLauncherConfig;
@@ -287,6 +288,13 @@ namespace CollapseLauncher.Pages
             Storyboard sb = btn.Resources["ExitStoryboard"] as Storyboard;
             btn.Translation -= Shadow16;
             sb.Begin();
+
+            Flyout flyout = btn.Resources["SocMedFlyout"] as Flyout;
+            Point pos = e.GetCurrentPoint(btn).Position;
+            if (pos.Y <= 0 || pos.Y >= btn.Height || pos.X <= -8 || pos.X >= btn.Width)
+            {
+                flyout.Hide();
+            }
         }
 
         private async void HideSocialMediaPanel(bool hide)
@@ -326,6 +334,34 @@ namespace CollapseLauncher.Pages
                     FileName = ((Button)sender).Tag.ToString()
                 }
             }.Start();
+        }
+
+        private void ShowSocMedFlyout(object sender, RoutedEventArgs e)
+        {
+            ToolTip tooltip = sender as ToolTip;
+            FlyoutBase.ShowAttachedFlyout(tooltip.Tag as FrameworkElement);
+        }
+
+        private void HideSocMedFlyout(object sender, RoutedEventArgs e)
+        {
+            Flyout flyout = ((StackPanel)sender).Tag as Flyout;
+            flyout.Hide();
+        }
+
+        private void OnLoadedSocMedFlyout(object sender, RoutedEventArgs e)
+        {
+            // Prevent the flyout showing when there is no content visible
+            StackPanel stackPanel = sender as StackPanel;
+            bool visible = false;
+            foreach (var child in stackPanel.Children)
+            {
+                if (child.Visibility == Visibility.Visible)
+                    visible = true;
+            }
+            if (!visible)
+            {
+                HideSocMedFlyout(sender, e);
+            }
         }
         #endregion
 
@@ -1762,12 +1798,24 @@ namespace CollapseLauncher.Pages
         #region Hyper Link Color
         private void HyperLink_OnPointerEntered(object sender, PointerRoutedEventArgs e)
         {
-            ((TextBlock)((Grid)sender).Children[0]).Foreground = (Brush)Application.Current.Resources["AccentColor"];
+            TextBlock textBlock = null;
+            if (sender is Grid grid)
+                textBlock = ((TextBlock)grid.Children[0]);
+            else if (sender is TextBlock block)
+                textBlock = block;
+            if (textBlock != null)
+                textBlock.Foreground = (Brush)Application.Current.Resources["AccentColor"];
         }
 
         private void HyperLink_OnPointerExited(object sender, PointerRoutedEventArgs e)
         {
-            ((TextBlock)((Grid)sender).Children[0]).Foreground = (Brush)Application.Current.Resources["TextFillColorPrimaryBrush"];
+            TextBlock textBlock = null;
+            if (sender is Grid grid)
+                textBlock = ((TextBlock)grid.Children[0]);
+            else if (sender is TextBlock block)
+                textBlock = block;
+            if (textBlock != null)
+                textBlock.Foreground = (Brush)Application.Current.Resources["TextFillColorPrimaryBrush"];
         }
         #endregion
 


### PR DESCRIPTION
Make use of the `links` and `other_links` fields, and add link buttons to popup panel, especially for Chinese version.

<details>
<summary>social media icon JSON here</summary>

```json
{
    "icon_id": "605077bbd90ba600951cd0e0",
    "img": "https://webstatic.mihoyo.com/upload/operation_location/2021/03/16/40247bcc1f0092a7883949aade6619ac_3149808684055343336.png",
    "tittle": "启动器常见问题FAQ",
    "url": "https://bbs.mihoyo.com/ys/article/4004423",
    "qr_img": "",
    "qr_desc": "",
    "img_hover": "https://webstatic.mihoyo.com/upload/operation_location/2021/03/16/021147ecf6824c3328d6c89b9c1b17e6_3771842119503074595.png",
    "other_links": [
        {
            "title": "启动器意见集中反馈",
            "url": "https://bbs.mihoyo.com/ys/article/5780277"
        }
    ],
    "title": "启动器常见问题FAQ",
    "icon_link": "https://www.miyoushe.com/ys/article/39655595",
    "links": [
        {
            "title": "常用FAQ合集",
            "url": "https://www.miyoushe.com/ys/article/39655595"
        },
        {
            "title": "启动器意见集中反馈",
            "url": "https://bbs.mihoyo.com/ys/article/5780277"
        }
    ],
    "enable_red_dot": false,
    "red_dot_content": ""
}
```
</details>

| old | new |
| --- | --- |
| <img src="https://github.com/neon-nyan/Collapse/assets/31368738/81912ef0-32a9-4a98-aa28-aa54652a881a" width="50%"/> | <img src="https://github.com/neon-nyan/Collapse/assets/31368738/8b2504f5-01a5-4e03-bf1e-18542dea7334" width="50%"/> |
