### PR TITLE
[Fix] Return null when Steam path is not found

### DIFF
--- a/CollapseLauncher/Classes/InstallManagement/BaseClass/InstallManagerBase.cs
+++ b/CollapseLauncher/Classes/InstallManagement/BaseClass/InstallManagerBase.cs
@@ -919,37 +919,29 @@ namespace CollapseLauncher.InstallManager.Base
 
         private bool TryGetExistingSteamPath(ref string OutputPath)
         {
-            try
-            {
-                // If the game preset doesn't have SteamGameID, then return false
-                if (_gameVersionManager.GamePreset.SteamGameID == null) return false;
-                // Assign Steam ID
-                int steamID = _gameVersionManager.GamePreset.SteamGameID ?? 0;
+            // If the game preset doesn't have SteamGameID, then return false
+            if (_gameVersionManager.GamePreset.SteamGameID == null) return false;
+            // Assign Steam ID
+            int steamID = _gameVersionManager.GamePreset.SteamGameID ?? 0;
 
-                // Try get the list of Steam Libs and Apps
-                List<string> steamLibsList = SteamTool.GetSteamLibs();
-                if (steamLibsList == null) return false;
+            // Try get the list of Steam Libs and Apps
+            List<string> steamLibsList = SteamTool.GetSteamLibs();
+            if (steamLibsList == null) return false;
 
-                List<SteamTool.AppInfo> steamAppList = SteamTool.GetSteamApps(steamLibsList);
+            List<SteamTool.AppInfo> steamAppList = SteamTool.GetSteamApps(steamLibsList);
 #nullable enable
-                SteamTool.AppInfo? steamAppInfo = steamAppList.Where(x => x.Id == steamID).FirstOrDefault();
+            SteamTool.AppInfo? steamAppInfo = steamAppList.Where(x => x.Id == steamID).FirstOrDefault();
 
-                // If the app info is not null, then assign OutputPath to the game path
-                if (steamAppInfo != null)
-                {
-                    OutputPath = steamAppInfo?.GameRoot;
-                    return true;
-                }
+            // If the app info is not null, then assign OutputPath to the game path
+            if (steamAppInfo != null)
+            {
+                OutputPath = steamAppInfo?.GameRoot;
+                return true;
+            }
 #nullable disable
 
-                // If none of them has it, then return false
-                return false;
-            }
-            catch (Exception ex)
-            {
-                LogWriteLine($"Failure when checking for Steam game installation! Treating as non-Steam installation\r\n\tPlease report this issue if you think this is not right.\r\n{ex}", LogType.Error, true);
-                return false;
-            }
+            // If none of them has it, then return false
+            return false;
         }
 
         private bool TryGetExistingBHI3LPath(ref string OutputPath)

--- a/Hi3Helper.Core/Classes/Data/Tools/SteamTool.cs
+++ b/Hi3Helper.Core/Classes/Data/Tools/SteamTool.cs
@@ -149,9 +149,18 @@ namespace Hi3Helper.Data
             var steamPath = GetSteamPath();
             var libraries = new List<string>() { steamPath };
 
-            if (steamPath == null) return null;
+            if (steamPath == null)
+            {
+                Logger.LogWriteLine("Steam not found. If you think this is an error report it on our GitHub.", LogType.Error, true);
+                return null;
+            }
 
             var listFile = Path.Combine(steamPath, @"steamapps\libraryfolders.vdf");
+            if (!File.Exists(listFile))
+            {
+                Logger.LogWriteLine("LibraryFolder.vdf not found. If you think this is an error report it on our GitHub.", LogType.Error, true);
+                return null;
+            }
             var lines = File.ReadAllLines(listFile);
             foreach (var line in lines)
             {
@@ -172,6 +181,7 @@ namespace Hi3Helper.Data
         {
             object a = Registry.GetValue(@"HKEY_CURRENT_USER\Software\Valve\Steam", "SteamPath", "C:/Program Files (x86)/Steam");
             if (a == null) return null;
+            if(!Directory.Exists(a as string)) return null;
             return ((string)a).Replace('\\', '/');
         }
 


### PR DESCRIPTION
This should fix any error related while trying to get steam path without throwing any exception.
