### PR TITLE
Fix calling UserFeedback dialog crashes app due to nulled game property

### DIFF
--- a/CollapseLauncher/XAMLs/Theme/CustomControls/UserFeedbackDialog/UserFeedbackDialog.cs
+++ b/CollapseLauncher/XAMLs/Theme/CustomControls/UserFeedbackDialog/UserFeedbackDialog.cs
@@ -5,6 +5,7 @@ using CollapseLauncher.Pages;
 using CollapseLauncher.Statics;
 using CommunityToolkit.WinUI;
 using Hi3Helper;
+using Hi3Helper.SentryHelper;
 using Hi3Helper.Shared.Region;
 using Microsoft.UI.Input;
 using Microsoft.UI.Text;
@@ -92,15 +93,25 @@ namespace CollapseLauncher.XAMLs.Theme.CustomControls.UserFeedbackDialog
             _layoutCloseButton?.EnableImplicitAnimation();
 
             // Assign dialog title image background
-            GamePresetProperty currentGameProperty = GamePropertyVault.GetCurrentGameProperty();
-            GameNameType       gameNameType        = currentGameProperty.GamePreset.GameType;
-            string relFilePath = gameNameType switch
+            var relFilePath = @"Assets\\Images\\GamePoster\\headerposter_genshin.png";
+            try
             {
-                GameNameType.Zenless => @"Assets\\Images\\GamePoster\\headerposter_zzz.png",
-                GameNameType.Honkai => @"Assets\\Images\\GamePoster\\headerposter_honkai.png",
-                GameNameType.StarRail => @"Assets\\Images\\GamePoster\\headerposter_starrail.png",
-                _ => @"Assets\\Images\\GamePoster\\headerposter_genshin.png"
-            };
+                var currentGameProperty = GamePropertyVault.GetCurrentGameProperty();
+                var gameNameType        = currentGameProperty.GamePreset.GameType;
+                relFilePath = gameNameType switch
+                                     {
+                                         GameNameType.Zenless => @"Assets\\Images\\GamePoster\\headerposter_zzz.png",
+                                         GameNameType.Honkai => @"Assets\\Images\\GamePoster\\headerposter_honkai.png",
+                                         GameNameType.StarRail => @"Assets\\Images\\GamePoster\\headerposter_starrail.png",
+                                         _ => @"Assets\\Images\\GamePoster\\headerposter_genshin.png"
+                                     };
+            }
+            catch (Exception ex)
+            {
+                SentryHelper.ExceptionHandler(ex);
+                Logger.LogWriteLine($"[UserFeedbackDialog::OnApplyTemplate] Failed to grab game type! Returning default game header..." +
+                                    $"\r\n{ex}", LogType.Error, true);
+            }
             // Get the title image background and load it.
             FileInfo filePathInfo = new(Path.Combine(LauncherConfig.AppExecutableDir, relFilePath));
             if (filePathInfo.Exists)
@@ -155,8 +166,8 @@ namespace CollapseLauncher.XAMLs.Theme.CustomControls.UserFeedbackDialog
             // Find an overlay grid where the UI element will be spawn to
             _parentOverlayGrid = XamlRoot.FindOverlayGrid(_isAlwaysOnTop);
             // Get the count of the Rows and Column so it can be spanned across the grid.
-            int parentGridRowCount = _parentOverlayGrid?.RowDefinitions.Count ?? 1;
-            int parentGridColumnCount = _parentOverlayGrid?.ColumnDefinitions.Count ?? 1;
+            var parentGridRowCount    = _parentOverlayGrid?.RowDefinitions.Count ?? 1;
+            var parentGridColumnCount = _parentOverlayGrid?.ColumnDefinitions.Count ?? 1;
             // Add the UI element to the grid
             _parentOverlayGrid?.AddElementToGridRowColumn(this,
                                                           0,
@@ -200,14 +211,14 @@ namespace CollapseLauncher.XAMLs.Theme.CustomControls.UserFeedbackDialog
         private void AssignLocalization()
         {
             // Assign locale for Text header, button, placeholders and stuffs...
-            _layoutTitleGridText?.BindProperty(TextBlock.TextProperty, Locale.Lang._Dialogs, nameof(Locale.Lang._Dialogs.UserFeedback_DialogTitle));
-            _layoutFeedbackTitleInput?.BindProperty(TextBox.PlaceholderTextProperty, Locale.Lang._Dialogs, nameof(Locale.Lang._Dialogs.UserFeedback_TextFieldTitlePlaceholder));
-            _layoutFeedbackMessageInput?.BindProperty(TextBox.PlaceholderTextProperty, Locale.Lang._Dialogs, nameof(Locale.Lang._Dialogs.UserFeedback_TextFieldMessagePlaceholder));
-            SetTextBoxPropertyHeaderLocale(_layoutFeedbackTitleInput, Locale.Lang._Dialogs.UserFeedback_TextFieldTitleHeader, Locale.Lang._Dialogs.UserFeedback_TextFieldRequired);
-            SetTextBoxPropertyHeaderLocale(_layoutFeedbackMessageInput, Locale.Lang._Dialogs.UserFeedback_TextFieldMessageHeader, Locale.Lang._Dialogs.UserFeedback_TextFieldRequired);
-            _layoutFeedbackRatingText?.BindProperty(TextBlock.TextProperty, Locale.Lang._Dialogs, nameof(Locale.Lang._Dialogs.UserFeedback_RatingText));
-            SetButtonPropertyTextLocale(_layoutPrimaryButton, Locale.Lang._Dialogs, nameof(Locale.Lang._Dialogs.UserFeedback_SubmitBtn));
-            SetButtonPropertyTextLocale(_layoutCloseButton, Locale.Lang._Dialogs, nameof(Locale.Lang._Dialogs.UserFeedback_CancelBtn));
+            _layoutTitleGridText?.BindProperty(TextBlock.TextProperty, Lang._Dialogs, nameof(Lang._Dialogs.UserFeedback_DialogTitle));
+            _layoutFeedbackTitleInput?.BindProperty(TextBox.PlaceholderTextProperty, Lang._Dialogs, nameof(Lang._Dialogs.UserFeedback_TextFieldTitlePlaceholder));
+            _layoutFeedbackMessageInput?.BindProperty(TextBox.PlaceholderTextProperty, Lang._Dialogs, nameof(Lang._Dialogs.UserFeedback_TextFieldMessagePlaceholder));
+            SetTextBoxPropertyHeaderLocale(_layoutFeedbackTitleInput, Lang._Dialogs.UserFeedback_TextFieldTitleHeader, Lang._Dialogs.UserFeedback_TextFieldRequired);
+            SetTextBoxPropertyHeaderLocale(_layoutFeedbackMessageInput, Lang._Dialogs.UserFeedback_TextFieldMessageHeader, Lang._Dialogs.UserFeedback_TextFieldRequired);
+            _layoutFeedbackRatingText?.BindProperty(TextBlock.TextProperty, Lang._Dialogs, nameof(Lang._Dialogs.UserFeedback_RatingText));
+            SetButtonPropertyTextLocale(_layoutPrimaryButton, Lang._Dialogs, nameof(Lang._Dialogs.UserFeedback_SubmitBtn));
+            SetButtonPropertyTextLocale(_layoutCloseButton, Lang._Dialogs, nameof(Lang._Dialogs.UserFeedback_CancelBtn));
         }
 
         private static void SetButtonPropertyTextLocale(Button? button, object localeObject, string nameOfLocale)

--- a/Hi3Helper.Core/Hi3Helper.Core.csproj
+++ b/Hi3Helper.Core/Hi3Helper.Core.csproj
@@ -43,7 +43,7 @@
 
     <ItemGroup>
       <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.3.0-prerelease.250720.1" />
-      <PackageReference Include="Sentry" Version="5.16.2" />
+      <PackageReference Include="Sentry" Version="6.0.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Hi3Helper.Core/packages.lock.json
+++ b/Hi3Helper.Core/packages.lock.json
@@ -16,14 +16,14 @@
       },
       "Sentry": {
         "type": "Direct",
-        "requested": "[5.16.2, )",
-        "resolved": "5.16.2",
-        "contentHash": "JZiKizATWdBe4dSdvMhp3d/TiMUug3VvWjiu9ZH5UfTbrwGWYUexZ4ZGdyrIB2GuWlLBUWs3Vi1GFv3pNhRKFg=="
+        "requested": "[6.0.0, )",
+        "resolved": "6.0.0",
+        "contentHash": "KomDnmKInN30NIaf52UsRYCK/QS8cBe1jV+JslxBzys30wPH0Wv0U20YQ2oJ65P0+XLv0JqNHmgAjN1zDy/fzQ=="
       },
       "Google.Protobuf": {
         "type": "Transitive",
-        "resolved": "3.33.1",
-        "contentHash": "RztiFmX9aOWDwfhxFzx/nS4fjs4DX7ZC7/XBEBl56k15lPGBftvbSwZkeo1mMCJHrNp1kK5iQYrFXB4MqCmBCA=="
+        "resolved": "3.33.2",
+        "contentHash": "vZXVbrZgBqUkP5iWQi0CS6pucIS2MQdEYPS1duWCo8fGrrt4th6HTiHfLFX2RmAWAQl1oUnzGgyDBsfq7fHQJA=="
       },
       "Microsoft.Extensions.DependencyInjection.Abstractions": {
         "type": "Transitive",
@@ -40,16 +40,16 @@
       },
       "System.IO.Hashing": {
         "type": "Transitive",
-        "resolved": "10.0.0",
-        "contentHash": "MqSp5IfX9RdWVwTED0WSRL1kZDNB7GlFj64O/NAJs4uO1beBHWEAFLlC7j8Fw/PkI+SUzooLVNvAe4aEkSwsRg=="
+        "resolved": "10.0.1",
+        "contentHash": "Dy6ULPb2S0GmNndjKrEIpfibNsc8+FTOoZnqygtFDuyun8vWboQbfMpQtKUXpgTxokR5E4zFHETpNnGfeWY6NA=="
       },
       "hi3helper.enctool": {
         "type": "Project",
         "dependencies": {
-          "Google.Protobuf": "[3.33.1, )",
+          "Google.Protobuf": "[3.33.2, )",
           "Hi3Helper.Http": "[2.0.0, )",
           "Hi3Helper.Win32": "[1.0.0, )",
-          "System.IO.Hashing": "[10.0.0, )"
+          "System.IO.Hashing": "[10.0.1, )"
         }
       },
       "hi3helper.http": {


### PR DESCRIPTION
closes #839


# Main Goal
Put the only thing GameProperty used (game header) inside a trycatch so it can fail when GameProperty is somehow broken.
Also general codeqa fixes

## PR Status :
- Overall Status : Done
- Commits : Done
- Synced to base (Collapse:main) : Yes
- Build status : OK
- Crashing : No
- Bug found caused by PR : 0

### Templates

<details>
  <summary>Changelog Prefixes</summary>
  
  ```
    **[New]**
    **[Imp]**
    **[Fix]**
    **[Loc]**
    **[Doc]**
  ```

</details>
