### PR TITLE
CRITICAL: Fix double dispose on LazyLoadBitmap

### DIFF
--- a/CollapseLauncher/XAMLs/MainApp/ValueConverters.cs
+++ b/CollapseLauncher/XAMLs/MainApp/ValueConverters.cs
@@ -718,7 +718,7 @@ namespace CollapseLauncher.Pages
                                                CancellationToken.None);
 
                 resultStream = result.Stream;
-                using IRandomAccessStream stream = resultStream.AsRandomAccessStream(true);
+                IRandomAccessStream stream = resultStream.AsRandomAccessStream(true);
                 image.ImageOpened += ImageOnImageOpened;
 
                 await image.SetSourceAsync(stream);


### PR DESCRIPTION


# Main Goal
Tryfix for launcher crash due to ODE during game/region switch.

This is caused by the `using` clause on the stream causing the resultStream to somehow getting double disposed during the event `ImageOnImageOpened` and crashes about 95% of the time during game/region change.

## PR Status :
- Overall Status : Done
- Commits : Done
- Synced to base (Collapse:main) : Yes
- Build status : OK
- Crashing : Yes
- Bug found caused by PR : 0

### Templates

<details>
  <summary>Changelog Prefixes</summary>
  
  ```
    **[New]**
    **[Imp]**
    **[Fix]**
    **[Loc]**
    **[Doc]**
  ```

</details>
