### PR TITLE
[INTERIM] fix(ui): Fix carousel still running after using StartOnTray

### DIFF
--- a/CollapseLauncher/XAMLs/MainApp/TrayIcon.xaml.cs
+++ b/CollapseLauncher/XAMLs/MainApp/TrayIcon.xaml.cs
@@ -292,6 +292,7 @@ namespace CollapseLauncher
                 MainTaskbarToggle.Text     = _showApp;
                 // Increase refresh rate to 1000ms when main window is hidden
                 RefreshRate = RefreshRateSlow;
+                m_homePage?.CarouselStopScroll();
                 LogWriteLine("Main window is hidden!");
 
                 // Spawn the hidden to tray toast notification
@@ -307,6 +308,7 @@ namespace CollapseLauncher
                 EfficiencyModeWrapper(false);
                 PInvoke.SetForegroundWindow(mainWindowHandle);
                 MainTaskbarToggle.Text = _hideApp;
+                m_homePage?.CarouselRestartScroll();
                 // Revert refresh rate to its default
                 RefreshRate = RefreshRateDefault;
                 LogWriteLine("Main window is shown!");


### PR DESCRIPTION
# Main Goal
This is interim commit before @neon-nyan take precedence over at  fecc199d91dbac8a1340399ec3683ec92895ad0a

1. Move CTSW creator outside while loop to prevent self recreation
2. Always pause carousel when window is not in foreground
3. Properly break  the for loop when CTS is called
4. Delay stop scroller to wait for scroller to initialize
5. Pause/resume carousel on tray activity

## PR Status :
- Overall Status : Done
- Commits : Done
- Synced to base (Collapse:main) : Yes
- Build status : OK
- Crashing : Yes
- Bug found caused by PR : -

### Templates

<details>
  <summary>Changelog Prefixes</summary>
  
  ```
    **[New]**
    **[Imp]**
    **[Fix]**
    **[Loc]**
    **[Doc]**
  ```

</details>
