### PR TITLE
[DiscordRPC] Fix non-functioning global toggle

### DIFF
--- a/CollapseLauncher/Classes/DiscordPresence/DiscordPresenceManager.cs
+++ b/CollapseLauncher/Classes/DiscordPresence/DiscordPresenceManager.cs
@@ -38,16 +38,13 @@ namespace CollapseLauncher.DiscordPresence
     {
         #region Properties
 
-        [field: NonSerialized]
-        private bool? _isRpcEnabled;
         public bool IsRpcEnabled
         {
-            get => _isRpcEnabled ??= GetAppConfigValue("EnableDiscordRPC").ToBoolNullable() ?? false;
+            get => field = GetAppConfigValue("EnableDiscordRPC");
             set
             {
-                if (_isRpcEnabled == value) return;
-
-                _isRpcEnabled = value;
+                if (field == value) return;
+                field = value;
 
                 SetAndSaveConfigValue("EnableDiscordRPC", value);
                 if (value) SetupPresence();

--- a/CollapseLauncher/Classes/RegionManagement/RegionManagement.cs
+++ b/CollapseLauncher/Classes/RegionManagement/RegionManagement.cs
@@ -489,7 +489,7 @@ namespace CollapseLauncher
 
             LogWriteLine($"Region changed to {Preset.ZoneFullname}", LogType.Scheme, true);
         #if !DISABLEDISCORD
-            if (GetAppConfigValue("EnableDiscordRPC").ToBool())
+            if (AppDiscordPresence.IsRpcEnabled)
                 AppDiscordPresence.SetupPresence();
         #endif
             return true;

--- a/CollapseLauncher/XAMLs/MainApp/MainPage.xaml.cs
+++ b/CollapseLauncher/XAMLs/MainApp/MainPage.xaml.cs
@@ -881,8 +881,8 @@ namespace CollapseLauncher
             if (await LoadRegionFromCurrentConfigV2(preset, gameName, gameRegion))
             {
             #if !DISABLEDISCORD
-                if (GetAppConfigValue("EnableDiscordRPC").ToBool() && !sameRegion)
-                    AppDiscordPresence?.SetupPresence();
+                if ((AppDiscordPresence?.IsRpcEnabled ?? false) && !sameRegion)
+                    AppDiscordPresence.SetupPresence();
             #endif
                 InvokeLoadingRegionPopup(false);
                 LauncherFrame.BackStack.Clear();

--- a/CollapseLauncher/XAMLs/MainApp/Pages/HomePage.xaml
+++ b/CollapseLauncher/XAMLs/MainApp/Pages/HomePage.xaml
@@ -2219,6 +2219,7 @@
                                                Style="{ThemeResource BodyStrongTextBlockStyle}"
                                                Text="{x:Bind helper:Locale.Lang._HomePage.GameSettings_Panel3RegionRpc}" />
                                     <ToggleSwitch x:Name="RegionRpcToggle"
+                                                  IsEnabled="{x:Bind IsRpcEnabled_QS}"
                                                   IsOn="{x:Bind ToggleRegionPlayingRpc, Mode=TwoWay}"
                                                   OffContent="{x:Bind helper:Locale.Lang._Misc.Disabled}"
                                                   OnContent="{x:Bind helper:Locale.Lang._Misc.Enabled}" />

--- a/CollapseLauncher/XAMLs/MainApp/Pages/HomePage.xaml.cs
+++ b/CollapseLauncher/XAMLs/MainApp/Pages/HomePage.xaml.cs
@@ -79,6 +79,8 @@ namespace CollapseLauncher.Pages
         private int barWidth;
         private int consoleWidth;
 
+        private readonly bool IsRpcEnabled_QS = AppDiscordPresence?.IsRpcEnabled ?? false; 
+
         public static int RefreshRateDefault => 500;
         public static int RefreshRateSlow    => 1000;
 

--- a/CollapseLauncher/XAMLs/MainApp/Pages/SettingsPage.xaml.cs
+++ b/CollapseLauncher/XAMLs/MainApp/Pages/SettingsPage.xaml.cs
@@ -769,9 +769,9 @@ namespace CollapseLauncher.Pages
         {
             get
             {
-                bool isEnabled = GetAppConfigValue("EnableDiscordRPC");
-                ToggleDiscordGameStatus.IsEnabled = IsEnabled;
-                if (isEnabled)
+                var e = AppDiscordPresence.IsRpcEnabled;
+                ToggleDiscordGameStatus.IsEnabled = e;
+                if (e)
                 {
                     ToggleDiscordGameStatus.Visibility = Visibility.Visible;
                     ToggleDiscordIdleStatus.Visibility = Visibility.Visible;
@@ -781,23 +781,22 @@ namespace CollapseLauncher.Pages
                     ToggleDiscordGameStatus.Visibility = Visibility.Collapsed;
                     ToggleDiscordIdleStatus.Visibility = Visibility.Collapsed;
                 }
-                return isEnabled;
+                return e;
             }
             set
             {
                 if (value)
                 {
-                    AppDiscordPresence.SetupPresence();
                     ToggleDiscordGameStatus.Visibility = Visibility.Visible;
                     ToggleDiscordIdleStatus.Visibility = Visibility.Visible;
                 }
                 else
                 {
-                    AppDiscordPresence.DisablePresence();
                     ToggleDiscordGameStatus.Visibility = Visibility.Collapsed;
                     ToggleDiscordIdleStatus.Visibility = Visibility.Collapsed;
                 }
-                SetAndSaveConfigValue("EnableDiscordRPC", value);
+
+                AppDiscordPresence.IsRpcEnabled   = value;
                 ToggleDiscordGameStatus.IsEnabled = value;
             }
         }


### PR DESCRIPTION
# Main Goal
Fix global RPC toggle not actually disabling RPC.
Also disable RPC regional setting when global toggle is set to disabled.

Closes #806 

## PR Status :
- Overall Status : Done
- Commits : Done
- Synced to base (Collapse:main) : Yes
- Build status : OK
- Crashing : No
- Bug found caused by PR : 0

### Templates

<details>
  <summary>Changelog Prefixes</summary>
  
  ```
    **[New]**
    **[Imp]**
    **[Fix]**
    **[Loc]**
    **[Doc]**
  ```

</details>
