### PR TITLE
[ZZZ GSP] Bring back DX12, RT, and Upscaling settings

### DIFF
--- a/CollapseLauncher/Classes/GameManagement/GameSettings/Zenless/Enums.cs
+++ b/CollapseLauncher/Classes/GameManagement/GameSettings/Zenless/Enums.cs
@@ -189,7 +189,7 @@ public enum AnisotropicSamplingOption
 public enum LocalUiLayoutPlatform
 {
     Mobile = 1,
-    PC = 3
+    PC = 2
 }
 
 public static class ServerName

--- a/CollapseLauncher/Classes/GameManagement/GameSettings/Zenless/FileClass/GeneralData.cs
+++ b/CollapseLauncher/Classes/GameManagement/GameSettings/Zenless/FileClass/GeneralData.cs
@@ -532,7 +532,7 @@ namespace CollapseLauncher.GameSettings.Zenless
             set => _envGlobalIllumination?.SetDataEnum(value);
         }
 
-        // Key 8 VSync
+        // Key 106 Motion Blur
         private SystemSettingLocalData<int>? _vMotionBlur;
 
         /// <summary>

--- a/CollapseLauncher/Classes/GameManagement/GameSettings/Zenless/Sleepy.cs
+++ b/CollapseLauncher/Classes/GameManagement/GameSettings/Zenless/Sleepy.cs
@@ -245,7 +245,7 @@ internal static class Sleepy
         if (*(evil + n))
         {
             byte eepy = 0;
-            if (*(bp + j) > 0x40)
+            if (*(bp + j) >= 0x40)
             {
                 ch   -= 0x40;
                 eepy =  1;

--- a/CollapseLauncher/XAMLs/MainApp/Pages/GameSettingsPages/ZenlessGameSettingsPage.xaml
+++ b/CollapseLauncher/XAMLs/MainApp/Pages/GameSettingsPages/ZenlessGameSettingsPage.xaml
@@ -1,4 +1,4 @@
-﻿<!--  ReSharper disable IdentifierTypo  -->
+<!--  ReSharper disable IdentifierTypo  -->
 <!--  ReSharper disable UnusedMember.Local  -->
 <!--  ReSharper disable Xaml.ConstructorWarning  -->
 <!--  ReSharper disable Xaml.RedundantNamespaceAlias  -->
@@ -221,7 +221,7 @@
                                           IsOn="{x:Bind AdvancedGraphics_UseDirectX12Api, Mode=TwoWay}"
                                           OffContent="{x:Bind helper:Locale.Lang._Misc.Disabled}"
                                           OnContent="{x:Bind helper:Locale.Lang._Misc.Enabled}"
-                                          Visibility="Collapsed">
+                                          Visibility="Visible">
                                 <ToggleSwitch.Header>
                                     <TextBlock>
                                         <Run Text="{x:Bind helper:Locale.Lang._ZenlessGameSettingsPage.AdvancedGraphics_UseDirectX12API}" />
@@ -576,11 +576,9 @@
                                     </CheckBox>
                                 </StackPanel>
                             </Grid>
-                            <MenuFlyoutSeparator Margin="8,16"
-                                                 Visibility="Collapsed" />
+                            <MenuFlyoutSeparator Margin="8,16" />
                             <StackPanel Orientation="Horizontal"
-                                        Spacing="16"
-                                        Visibility="Collapsed">
+                                        Spacing="16">
                                 <TextBlock Margin="0,0,0,16"
                                            Style="{ThemeResource SubtitleTextBlockStyle}"
                                            TextWrapping="Wrap">
@@ -629,8 +627,7 @@
                                         <ColumnDefinition />
                                         <ColumnDefinition />
                                     </Grid.ColumnDefinitions>
-                                    <StackPanel Grid.Column="0"
-                                                Visibility="Collapsed">
+                                    <StackPanel Grid.Column="0">
                                         <ItemsControl IsEnabled="{x:Bind ToggleSwitchUseDirectX12Api.IsOn, Mode=OneWay}">
                                             <TextBlock Margin="0,0,8,8"
                                                        HorizontalAlignment="Left"
@@ -643,8 +640,7 @@
                                                           OnContent="{x:Bind helper:Locale.Lang._Misc.Enabled}" />
                                         </ItemsControl>
                                     </StackPanel>
-                                    <StackPanel Grid.Column="1"
-                                                Visibility="Collapsed">
+                                    <StackPanel Grid.Column="1">
                                         <ItemsControl IsEnabled="{x:Bind ToggleSwitchUseDirectX12Api.IsOn, Mode=OneWay}">
                                             <TextBlock Margin="0,0,8,8"
                                                        HorizontalAlignment="Left"
@@ -661,8 +657,7 @@
                                             </ComboBox>
                                         </ItemsControl>
                                     </StackPanel>
-                                    <StackPanel Grid.Column="2"
-                                                Visibility="Collapsed">
+                                    <StackPanel Grid.Column="2">
                                         <ItemsControl IsEnabled="{x:Bind ToggleSwitchUseDirectX12Api.IsOn, Mode=OneWay}">
                                             <TextBlock Margin="0,0,8,8"
                                                        HorizontalAlignment="Left"
@@ -678,8 +673,7 @@
                                             </ComboBox>
                                         </ItemsControl>
                                     </StackPanel>
-                                    <StackPanel Grid.Column="3"
-                                                Visibility="Collapsed">
+                                    <StackPanel Grid.Column="3">
                                         <ItemsControl IsEnabled="{x:Bind ToggleSwitchUseDirectX12Api.IsOn, Mode=OneWay}">
                                             <TextBlock Margin="0,0,8,8"
                                                        HorizontalAlignment="Left"


### PR DESCRIPTION

# Main Goal
The settings is back on 2.5, the option were made by neon before but hidden because it was removed at 2.4.

I still can't find the correlation with some of the new values under SystemsSettingDataMap as the value did not changed accordingly to the game settings. But the current implementation should be enough for what it is, as no new game settings were introduced.

<img width="1282" height="721" alt="image" src="https://github.com/user-attachments/assets/2a351b76-b417-4009-a7f7-a8a14a6a0fb2" />
<img width="2559" height="1438" alt="image" src="https://github.com/user-attachments/assets/0fa778bf-c506-406f-895f-603b3894cffb" />
<img width="2559" height="1438" alt="image" src="https://github.com/user-attachments/assets/af97ece9-9b51-403b-b70e-d698067d4031" />


## PR Status :
- Overall Status : Done
- Commits : Done
- Synced to base (Collapse:main) : Yes
- Build status : OK
- Crashing : Yes
- Bug found caused by PR : 0

### Templates

<details>
  <summary>Changelog Prefixes</summary>
  
  ```
    **[New]**
    **[Imp]**
    **[Fix]**
    **[Loc]**
    **[Doc]**
  ```

</details>
