### PR TITLE
[UX] Put game file cleanup button to navigation bar

### DIFF
--- a/CollapseLauncher/XAMLs/MainApp/MainPage.Navigation.cs
+++ b/CollapseLauncher/XAMLs/MainApp/MainPage.Navigation.cs
@@ -5,6 +5,7 @@ using CollapseLauncher.Interfaces;
 using CollapseLauncher.Pages;
 using CommunityToolkit.WinUI;
 using Hi3Helper;
+using Hi3Helper.SentryHelper;
 using Microsoft.UI;
 using Microsoft.UI.Input;
 using Microsoft.UI.Xaml;
@@ -268,12 +269,23 @@ public partial class MainPage : Page
                 LoadingMessageHelper.SetMessage(Lang._FileCleanupPage.LoadingTitle,
                                                 Lang._FileCleanupPage.LoadingSubtitle2);
 
-                if (CurrentGameProperty?.GameInstall != null)
-                    await CurrentGameProperty.GameInstall.CleanUpGameFiles();
+                try
+                {
+                    if (CurrentGameProperty?.GameInstall != null)
+                        await CurrentGameProperty.GameInstall.CleanUpGameFiles();
+                }
+                catch (Exception ex)
+                {
+                    LoadingMessageHelper.HideLoadingFrame();
+                    LogWriteLine($"[NavigateInnerSwitch(filescleanup] Error while calling the CleanUpGameFiles method! \r\n {ex}", LogType.Error, true);
+                    await SentryHelper.ExceptionHandlerAsync(ex);
+
+                    ErrorSender.SendException(ex);
+                }
 
                 // Manually reselect last item in toolbar as CleanUp is an overlay
                 NavigationViewControl.SelectedItem = NavigationViewControl.MenuItems.OfType<NavigationViewItem>()
-                                                       .FirstOrDefault(x => x.Tag is string tag && tag == PreviousTag); ;
+                                                       .FirstOrDefault(x => x.Tag is string tag && tag == PreviousTag);
                 break;
 
             case "repair":

--- a/CollapseLauncher/XAMLs/MainApp/MainPage.Navigation.cs
+++ b/CollapseLauncher/XAMLs/MainApp/MainPage.Navigation.cs
@@ -1,4 +1,5 @@
 using CollapseLauncher.Extension;
+using CollapseLauncher.Helper.Loading;
 using CollapseLauncher.Helper.Metadata;
 using CollapseLauncher.Interfaces;
 using CollapseLauncher.Pages;
@@ -15,6 +16,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using static CollapseLauncher.InnerLauncherConfig;
 using static CollapseLauncher.Statics.GamePropertyVault;
+using static Hi3Helper.Locale;
 using static Hi3Helper.Logger;
 using static Hi3Helper.Shared.Region.LauncherConfig;
 
@@ -51,6 +53,7 @@ public partial class MainPage : Page
             FontIcon IconCaches = new FontIcon { Glyph = m_isWindows11 ? "" : "" };
             FontIcon IconGameSettings = new FontIcon { Glyph = "" };
             FontIcon IconAppSettings = new FontIcon { Glyph = "" };
+            FontIcon IconFilesCleanup = new FontIcon { Glyph = "" };
 
             if (m_appMode == AppMode.Hi3CacheUpdater)
             {
@@ -108,6 +111,10 @@ public partial class MainPage : Page
                                                                  .BindNavigationViewItemText("_GameSettingsPage", "PageTitle"));
                     break;
             }
+
+            NavigationViewControl.FooterMenuItems.Add(new NavigationViewItem
+                                                            { Icon = IconFilesCleanup, Tag = "filescleanup"}
+                                                        .BindNavigationViewItemText("_FileCleanupPage", "Title"));
 
             if (NavigationViewControl.SettingsItem is NavigationViewItem SettingsItem)
             {
@@ -246,13 +253,27 @@ public partial class MainPage : Page
         NavigateInnerSwitch(itemTag);
     }
 
-    private void NavigateInnerSwitch(string itemTag)
+    private async void NavigateInnerSwitch(string itemTag)
     {
         if (itemTag == PreviousTag) return;
         switch (itemTag)
         {
             case "launcher":
                 Navigate(typeof(HomePage), itemTag);
+                break;
+
+            case "filescleanup":
+                LoadingMessageHelper.ShowLoadingFrame();
+                // Initialize and get game state, then get the latest package info
+                LoadingMessageHelper.SetMessage(Lang._FileCleanupPage.LoadingTitle,
+                                                Lang._FileCleanupPage.LoadingSubtitle2);
+
+                if (CurrentGameProperty?.GameInstall != null)
+                    await CurrentGameProperty.GameInstall.CleanUpGameFiles();
+
+                // Manually reselect last item in toolbar as CleanUp is an overlay
+                NavigationViewControl.SelectedItem = NavigationViewControl.MenuItems.OfType<NavigationViewItem>()
+                                                       .FirstOrDefault(x => x.Tag is string tag && tag == PreviousTag); ;
                 break;
 
             case "repair":

--- a/CollapseLauncher/XAMLs/MainApp/MainPage.Navigation.cs
+++ b/CollapseLauncher/XAMLs/MainApp/MainPage.Navigation.cs
@@ -277,8 +277,7 @@ public partial class MainPage : Page
                 catch (Exception ex)
                 {
                     LoadingMessageHelper.HideLoadingFrame();
-                    LogWriteLine($"[NavigateInnerSwitch(filescleanup] Error while calling the CleanUpGameFiles method! \r\n {ex}", LogType.Error, true);
-                    await SentryHelper.ExceptionHandlerAsync(ex);
+                    LogWriteLine($"[NavigateInnerSwitch(filescleanup] Error while calling the CleanUpGameFiles method!\r\n{ex}", LogType.Error, true);
 
                     ErrorSender.SendException(ex);
                 }


### PR DESCRIPTION
# Main Goal
Makes the feature more accessible and seen by users instead of it being buried inside Quick Settings.

Screenshots
<img width="1333" height="735" alt="image" src="https://github.com/user-attachments/assets/6cba7d85-cdc5-49cf-986e-626f318eb6b8" />
<img width="1282" height="721" alt="image" src="https://github.com/user-attachments/assets/c9a6cc21-a73a-42a1-b07e-31ce75daccb3" />

closes #725 
## PR Status :
- Overall Status : Done
- Commits : Done
- Synced to base (Collapse:main) : Yes
- Build status : OK
- Crashing : No
- Bug found caused by PR : 0

### Templates

<details>
  <summary>Changelog Prefixes</summary>
  
  ```
    **[New]**
    **[Imp]**
    **[Fix]**
    **[Loc]**
    **[Doc]**
  ```

</details>
