### PR TITLE
Fix drag mechanism in Plugin Management Menu

### DIFF
--- a/CollapseLauncher/Classes/Helper/WindowUtility.cs
+++ b/CollapseLauncher/Classes/Helper/WindowUtility.cs
@@ -447,7 +447,7 @@ namespace CollapseLauncher.Helper
 
             dragPosition = default;
             nint windowHandle = CurrentWindowPtr;
-            if (windowHandle == nint.Zero || windowHandle == PInvoke.GetForegroundWindow())
+            if (windowHandle == nint.Zero)
             {
                 return false;
             }

--- a/CollapseLauncher/Classes/Helper/WindowUtility.cs
+++ b/CollapseLauncher/Classes/Helper/WindowUtility.cs
@@ -53,9 +53,10 @@ namespace CollapseLauncher.Helper
     }
 
     internal delegate nint WndProcDelegate(nint hwnd, uint msg, nuint wParam, nint lParam);
-    internal static class WindowUtility
+    internal static partial class WindowUtility
     {
         private static event EventHandler<RectInt32[]>? DragAreaChangeEvent;
+        internal static event Action<string[], PointInt32>? FileDropEvent;
 
         private static nint _oldMainWndProcPtr;
         private static nint _oldDesktopSiteBridgeWndProcPtr;
@@ -417,6 +418,52 @@ namespace CollapseLauncher.Helper
             FileDialogNative.InitHandlerPointer(CurrentWindowPtr);
         }
 
+        internal static void SetFileDropEnabled(bool isEnabled)
+        {
+            const uint WM_COPYDATA       = 0x004A;
+            const uint WM_COPYGLOBALDATA = 0x0049;
+            const uint WM_DROPFILES      = 0x0233;
+            const uint MSGFLT_RESET      = 0;
+            const uint MSGFLT_ALLOW      = 1;
+
+            nint windowHandle = CurrentWindowPtr;
+            if (windowHandle == nint.Zero)
+            {
+                return;
+            }
+
+            uint messageFilterAction = isEnabled ? MSGFLT_ALLOW : MSGFLT_RESET;
+            NativeFileDrop.ChangeWindowMessageFilterEx(windowHandle, WM_DROPFILES, messageFilterAction, nint.Zero);
+            NativeFileDrop.ChangeWindowMessageFilterEx(windowHandle, WM_COPYDATA, messageFilterAction, nint.Zero);
+            NativeFileDrop.ChangeWindowMessageFilterEx(windowHandle, WM_COPYGLOBALDATA, messageFilterAction, nint.Zero);
+            NativeFileDrop.DragAcceptFiles(windowHandle, isEnabled);
+        }
+
+        internal static bool TryGetExternalDragPosition(out PointInt32 dragPosition)
+        {
+            const int VK_LBUTTON = 0x01;
+            const int VK_RBUTTON = 0x02;
+            const int KeyPressed = 0x8000;
+
+            dragPosition = default;
+            nint windowHandle = CurrentWindowPtr;
+            if (windowHandle == nint.Zero || windowHandle == PInvoke.GetForegroundWindow())
+            {
+                return false;
+            }
+
+            bool isMouseButtonPressed = (NativeFileDrop.GetAsyncKeyState(VK_LBUTTON) & KeyPressed) != 0 ||
+                                        (NativeFileDrop.GetAsyncKeyState(VK_RBUTTON) & KeyPressed) != 0;
+            if (!isMouseButtonPressed || !NativeFileDrop.GetCursorPos(out NativePoint cursorPosition))
+            {
+                return false;
+            }
+
+            NativeFileDrop.ScreenToClient(windowHandle, ref cursorPosition);
+            dragPosition = new PointInt32(cursorPosition.X, cursorPosition.Y);
+            return true;
+        }
+
         #region Drag Area Handler
 
         private static void InstallDragAreaChangeMonitor()
@@ -496,6 +543,7 @@ namespace CollapseLauncher.Helper
             const uint WM_ACTIVATE        = 0x0006;
             const uint WM_QUERYENDSESSION = 0x0011;
             const uint WM_ENDSESSION      = 0x0016;
+            const uint WM_DROPFILES       = 0x0233;
 
             switch (msg)
             {
@@ -643,9 +691,86 @@ namespace CollapseLauncher.Helper
                         (CurrentWindow as MainWindow)?.CloseApp();
                     }
                     break;
+                case WM_DROPFILES:
+                    HandleFileDrop((nint)wParam);
+                    return 0;
             }
 
             return PInvoke.CallWindowProc(_oldMainWndProcPtr, hwnd, msg, wParam, lParam);
+        }
+
+        private static unsafe void HandleFileDrop(nint dropHandle)
+        {
+            const uint GetFileCount = uint.MaxValue;
+
+            try
+            {
+                int fileCount = (int)NativeFileDrop.DragQueryFile(dropHandle, GetFileCount, null, 0);
+                string[] files = new string[fileCount];
+                for (int i = 0; i < fileCount; i++)
+                {
+                    uint filePathLength = NativeFileDrop.DragQueryFile(dropHandle, (uint)i, null, 0);
+                    char[] filePathBuffer = new char[filePathLength + 1];
+                    fixed (char* filePathBufferPtr = filePathBuffer)
+                    {
+                        NativeFileDrop.DragQueryFile(dropHandle, (uint)i, filePathBufferPtr, (uint)filePathBuffer.Length);
+                        files[i] = new string(filePathBufferPtr, 0, (int)filePathLength);
+                    }
+                }
+
+                NativeFileDrop.DragQueryPoint(dropHandle, out NativePoint dropPoint);
+                FileDropEvent?.Invoke(files, new PointInt32(dropPoint.X, dropPoint.Y));
+            }
+            finally
+            {
+                NativeFileDrop.DragFinish(dropHandle);
+            }
+        }
+
+        private static unsafe partial class NativeFileDrop
+        {
+            [LibraryImport("shell32.dll")]
+            [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
+            internal static partial void DragAcceptFiles(nint windowHandle, [MarshalAs(UnmanagedType.Bool)] bool acceptFiles);
+
+            [LibraryImport("shell32.dll", EntryPoint = "DragQueryFileW")]
+            [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
+            internal static partial uint DragQueryFile(nint dropHandle, uint fileIndex, char* filePath, uint filePathLength);
+
+            [LibraryImport("shell32.dll")]
+            [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
+            [return: MarshalAs(UnmanagedType.Bool)]
+            internal static partial bool DragQueryPoint(nint dropHandle, out NativePoint dropPoint);
+
+            [LibraryImport("shell32.dll")]
+            [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
+            internal static partial void DragFinish(nint dropHandle);
+
+            [LibraryImport("user32.dll")]
+            [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
+            [return: MarshalAs(UnmanagedType.Bool)]
+            internal static partial bool ChangeWindowMessageFilterEx(nint windowHandle, uint message, uint action, nint changeFilterStruct);
+
+            [LibraryImport("user32.dll")]
+            [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
+            internal static partial short GetAsyncKeyState(int virtualKey);
+
+            [LibraryImport("user32.dll")]
+            [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
+            [return: MarshalAs(UnmanagedType.Bool)]
+            internal static partial bool GetCursorPos(out NativePoint cursorPosition);
+
+            [LibraryImport("user32.dll")]
+            [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
+            [return: MarshalAs(UnmanagedType.Bool)]
+            internal static partial bool ScreenToClient(nint windowHandle, ref NativePoint cursorPosition);
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        private struct NativePoint
+        {
+            internal int X;
+            internal int Y;
         }
 
         #endregion

--- a/CollapseLauncher/Classes/Helper/WindowUtility.cs
+++ b/CollapseLauncher/Classes/Helper/WindowUtility.cs
@@ -53,7 +53,7 @@ namespace CollapseLauncher.Helper
     }
 
     internal delegate nint WndProcDelegate(nint hwnd, uint msg, nuint wParam, nint lParam);
-    internal static partial class WindowUtility
+    internal static class WindowUtility
     {
         private static event EventHandler<RectInt32[]>? DragAreaChangeEvent;
         internal static event Action<string[], PointInt32>? FileDropEvent;
@@ -433,10 +433,10 @@ namespace CollapseLauncher.Helper
             }
 
             uint messageFilterAction = isEnabled ? MSGFLT_ALLOW : MSGFLT_RESET;
-            NativeFileDrop.ChangeWindowMessageFilterEx(windowHandle, WM_DROPFILES, messageFilterAction, nint.Zero);
-            NativeFileDrop.ChangeWindowMessageFilterEx(windowHandle, WM_COPYDATA, messageFilterAction, nint.Zero);
-            NativeFileDrop.ChangeWindowMessageFilterEx(windowHandle, WM_COPYGLOBALDATA, messageFilterAction, nint.Zero);
-            NativeFileDrop.DragAcceptFiles(windowHandle, isEnabled);
+            PInvoke.ChangeWindowMessageFilterEx(windowHandle, WM_DROPFILES,      messageFilterAction, nint.Zero);
+            PInvoke.ChangeWindowMessageFilterEx(windowHandle, WM_COPYDATA,       messageFilterAction, nint.Zero);
+            PInvoke.ChangeWindowMessageFilterEx(windowHandle, WM_COPYGLOBALDATA, messageFilterAction, nint.Zero);
+            PInvoke.DragAcceptFiles(windowHandle, isEnabled);
         }
 
         internal static bool TryGetExternalDragPosition(out PointInt32 dragPosition)
@@ -452,15 +452,15 @@ namespace CollapseLauncher.Helper
                 return false;
             }
 
-            bool isMouseButtonPressed = (NativeFileDrop.GetAsyncKeyState(VK_LBUTTON) & KeyPressed) != 0 ||
-                                        (NativeFileDrop.GetAsyncKeyState(VK_RBUTTON) & KeyPressed) != 0;
-            if (!isMouseButtonPressed || !NativeFileDrop.GetCursorPos(out NativePoint cursorPosition))
+            bool isMouseButtonPressed = (PInvoke.GetAsyncKeyState(VK_LBUTTON) & KeyPressed) != 0 ||
+                                        (PInvoke.GetAsyncKeyState(VK_RBUTTON) & KeyPressed) != 0;
+            if (!isMouseButtonPressed || !PInvoke.GetCursorPos(out POINTL cursorPosition))
             {
                 return false;
             }
 
-            NativeFileDrop.ScreenToClient(windowHandle, ref cursorPosition);
-            dragPosition = new PointInt32(cursorPosition.X, cursorPosition.Y);
+            PInvoke.ScreenToClient(windowHandle, ref cursorPosition);
+            dragPosition = new PointInt32(cursorPosition.x, cursorPosition.y);
             return true;
         }
 
@@ -692,85 +692,19 @@ namespace CollapseLauncher.Helper
                     }
                     break;
                 case WM_DROPFILES:
-                    HandleFileDrop((nint)wParam);
+                    if (NativeFileDrop.TryHandleFileDrop((nint)wParam,
+                                                         out string[]? files,
+                                                         out POINTL dropPoint,
+                                                         out Exception? ex))
+                    {
+                        FileDropEvent?.Invoke(files, new PointInt32(dropPoint.x, dropPoint.y));
+                    }
+
+                    if (ex != null) ErrorSender.SendException(ex);
                     return 0;
             }
 
             return PInvoke.CallWindowProc(_oldMainWndProcPtr, hwnd, msg, wParam, lParam);
-        }
-
-        private static unsafe void HandleFileDrop(nint dropHandle)
-        {
-            const uint GetFileCount = uint.MaxValue;
-
-            try
-            {
-                int fileCount = (int)NativeFileDrop.DragQueryFile(dropHandle, GetFileCount, null, 0);
-                string[] files = new string[fileCount];
-                for (int i = 0; i < fileCount; i++)
-                {
-                    uint filePathLength = NativeFileDrop.DragQueryFile(dropHandle, (uint)i, null, 0);
-                    char[] filePathBuffer = new char[filePathLength + 1];
-                    fixed (char* filePathBufferPtr = filePathBuffer)
-                    {
-                        NativeFileDrop.DragQueryFile(dropHandle, (uint)i, filePathBufferPtr, (uint)filePathBuffer.Length);
-                        files[i] = new string(filePathBufferPtr, 0, (int)filePathLength);
-                    }
-                }
-
-                NativeFileDrop.DragQueryPoint(dropHandle, out NativePoint dropPoint);
-                FileDropEvent?.Invoke(files, new PointInt32(dropPoint.X, dropPoint.Y));
-            }
-            finally
-            {
-                NativeFileDrop.DragFinish(dropHandle);
-            }
-        }
-
-        private static unsafe partial class NativeFileDrop
-        {
-            [LibraryImport("shell32.dll")]
-            [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
-            internal static partial void DragAcceptFiles(nint windowHandle, [MarshalAs(UnmanagedType.Bool)] bool acceptFiles);
-
-            [LibraryImport("shell32.dll", EntryPoint = "DragQueryFileW")]
-            [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
-            internal static partial uint DragQueryFile(nint dropHandle, uint fileIndex, char* filePath, uint filePathLength);
-
-            [LibraryImport("shell32.dll")]
-            [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
-            [return: MarshalAs(UnmanagedType.Bool)]
-            internal static partial bool DragQueryPoint(nint dropHandle, out NativePoint dropPoint);
-
-            [LibraryImport("shell32.dll")]
-            [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
-            internal static partial void DragFinish(nint dropHandle);
-
-            [LibraryImport("user32.dll")]
-            [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
-            [return: MarshalAs(UnmanagedType.Bool)]
-            internal static partial bool ChangeWindowMessageFilterEx(nint windowHandle, uint message, uint action, nint changeFilterStruct);
-
-            [LibraryImport("user32.dll")]
-            [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
-            internal static partial short GetAsyncKeyState(int virtualKey);
-
-            [LibraryImport("user32.dll")]
-            [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
-            [return: MarshalAs(UnmanagedType.Bool)]
-            internal static partial bool GetCursorPos(out NativePoint cursorPosition);
-
-            [LibraryImport("user32.dll")]
-            [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
-            [return: MarshalAs(UnmanagedType.Bool)]
-            internal static partial bool ScreenToClient(nint windowHandle, ref NativePoint cursorPosition);
-        }
-
-        [StructLayout(LayoutKind.Sequential)]
-        private struct NativePoint
-        {
-            internal int X;
-            internal int Y;
         }
 
         #endregion

--- a/CollapseLauncher/Classes/Helper/WindowUtility.cs
+++ b/CollapseLauncher/Classes/Helper/WindowUtility.cs
@@ -700,7 +700,11 @@ namespace CollapseLauncher.Helper
                         FileDropEvent?.Invoke(files, new PointInt32(dropPoint.x, dropPoint.y));
                     }
 
-                    if (ex != null) ErrorSender.SendException(ex);
+                    if (ex != null)
+                    {
+                        ErrorSender.SendException(ex);
+                        SentryHelper.ExceptionHandler(ex);
+                    }
                     return 0;
             }
 

--- a/CollapseLauncher/Classes/Plugins/PluginImporter.cs
+++ b/CollapseLauncher/Classes/Plugins/PluginImporter.cs
@@ -1,5 +1,6 @@
 ﻿using Hi3Helper.Plugin.Core.Update;
 using Hi3Helper.Shared.Region;
+using CollapseLauncher.Helper.StreamUtility;
 using System;
 using System.Data;
 using System.IO;
@@ -15,6 +16,14 @@ internal static partial class PluginImporter
     public static async Task<PluginInfo> AutoGetImportFromPath(string filePath, CancellationToken token)
     {
         bool isFromPackage = filePath.EndsWith(".zip", StringComparison.OrdinalIgnoreCase);
+        bool isFromManifest = string.Equals(Path.GetFileName(filePath),
+                                            PluginManager.ManifestPrefix,
+                                            StringComparison.OrdinalIgnoreCase);
+
+        if (!isFromPackage && !isFromManifest)
+        {
+            throw new NotSupportedException($"{Path.GetFileName(filePath)} is not supported. Import a .zip package or a file named manifest.json.");
+        }
 
         using IPluginSource pluginSource = isFromPackage ?
             await ZipPluginSource.GetSourceFrom(filePath, token) :
@@ -24,6 +33,7 @@ internal static partial class PluginImporter
         string pluginDirName       = $"Hi3Helper.Plugin.{pluginExecNameNoExt}";
         string pluginBaseDir       = Path.Combine(LauncherConfig.AppPluginFolder, pluginDirName);
         string pluginRelName       = Path.Combine(pluginDirName, pluginSource.Manifest.MainLibraryName);
+        string pluginEntryPath     = GetContainedPath(pluginBaseDir, pluginSource.Manifest.MainLibraryName);
 
         if (PluginManager.PluginInstances.ContainsKey(pluginBaseDir) ||
             PluginManager.PluginInstances.Values
@@ -44,25 +54,64 @@ internal static partial class PluginImporter
             });
         }
 
-        string pluginEntryPath = Path.Combine(pluginBaseDir, pluginSource.Manifest.MainLibraryName);
-        foreach (PluginManifestAssetInfo asset in pluginSource.Manifest.Assets)
-        {
-            string  assetFullPath = Path.Combine(pluginBaseDir, asset.FilePath);
-            string? assetFullDir  = Path.GetDirectoryName(assetFullPath);
+        Directory.CreateDirectory(LauncherConfig.AppPluginFolder);
+        string stagingDir = Path.Combine(LauncherConfig.AppPluginFolder, $".import-{Guid.NewGuid():N}");
+        string cleanupDir = stagingDir;
 
-            if (!string.IsNullOrEmpty(assetFullDir))
+        try
+        {
+            foreach (PluginManifestAssetInfo asset in pluginSource.Manifest.Assets)
             {
-                Directory.CreateDirectory(assetFullDir);
+                string  assetFullPath = GetContainedPath(stagingDir, asset.FilePath);
+                string? assetFullDir  = Path.GetDirectoryName(assetFullPath);
+
+                if (!string.IsNullOrEmpty(assetFullDir))
+                {
+                    Directory.CreateDirectory(assetFullDir);
+                }
+
+                await using FileStream assetStream             = File.Create(assetFullPath);
+                await using Stream     assetPluginSourceStream = await pluginSource.GetAssetStream(asset, token);
+
+                await assetPluginSourceStream.CopyToAsync(assetStream, token);
             }
 
-            await using FileStream assetStream             = File.Create(assetFullPath);
-            await using Stream     assetPluginSourceStream = await pluginSource.GetAssetStream(asset, token);
+            Directory.Move(stagingDir, pluginBaseDir);
+            cleanupDir = pluginBaseDir;
 
-            await assetPluginSourceStream.CopyToAsync(assetStream, token);
+            PluginInfo pluginInfo = new(pluginEntryPath,
+                                         pluginRelName,
+                                         pluginSource.Manifest);
+            cleanupDir = string.Empty;
+            return pluginInfo;
+        }
+        catch
+        {
+            if (!string.IsNullOrEmpty(cleanupDir))
+            {
+                new DirectoryInfo(cleanupDir).TryDeleteDirectory(true);
+            }
+
+            throw;
+        }
+    }
+
+    private static string GetContainedPath(string baseDirectory, string relativePath)
+    {
+        if (string.IsNullOrWhiteSpace(relativePath))
+        {
+            throw new InvalidDataException("The plugin manifest contains an empty file path.");
         }
 
-        return new PluginInfo(pluginEntryPath,
-                              pluginRelName,
-                              pluginSource.Manifest);
+        string baseFullPath = Path.TrimEndingDirectorySeparator(Path.GetFullPath(baseDirectory));
+        string fileFullPath = Path.GetFullPath(relativePath, baseFullPath);
+        string basePrefix   = baseFullPath + Path.DirectorySeparatorChar;
+
+        if (!fileFullPath.StartsWith(basePrefix, StringComparison.OrdinalIgnoreCase))
+        {
+            throw new InvalidDataException($"The plugin manifest path '{relativePath}' points outside the plugin directory.");
+        }
+
+        return fileFullPath;
     }
 }

--- a/CollapseLauncher/XAMLs/MainApp/Pages/HomePage.Background.cs
+++ b/CollapseLauncher/XAMLs/MainApp/Pages/HomePage.Background.cs
@@ -148,8 +148,8 @@ public sealed partial class HomePage
         }
         else
         {
-            PInvoke.GetCursorPos(out pointerPos).ThrowOnFailure();
-            PInvoke.ScreenToClient(WindowUtility.CurrentWindowPtr, ref pointerPos).ThrowOnFailure();
+            PInvoke.GetCursorPos(out pointerPos);
+            PInvoke.ScreenToClient(WindowUtility.CurrentWindowPtr, ref pointerPos);
         }
 
         double xFrom = gridPos.X;

--- a/CollapseLauncher/XAMLs/MainApp/Pages/PluginManagerPage.xaml
+++ b/CollapseLauncher/XAMLs/MainApp/Pages/PluginManagerPage.xaml
@@ -823,12 +823,17 @@
                 </ResourceDictionary>
             </Grid.Resources>
             <Button x:Name="ImportBoxButton"
+                    AllowDrop="True"
                     HorizontalAlignment="Stretch"
                     VerticalAlignment="Stretch"
                     extension:UIElementExtensions.CursorType="Hand"
                     Background="{StaticResource ImportBoxButtonBackground}"
                     Click="OnClickImportButton"
-                    CornerRadius="20">
+                    CornerRadius="20"
+                    DragEnter="OnDragEnterImportBox"
+                    DragLeave="OnDragLeaveImportBox"
+                    DragOver="OnDragOverImportBox"
+                    Drop="OnDropImportBox">
                 <interactivity:Interaction.Behaviors>
                     <interactivity:EventTriggerBehavior EventName="PointerEntered">
                         <behaviors:StartAnimationAction Animation="{x:Bind ImportBoxPlusGridEnterAnimation}" />
@@ -906,7 +911,7 @@
                             </animations:AnimationSet>
                         </animations:Explicit.Animations>
 
-                        <FontIcon FontSize="48z"
+                        <FontIcon FontSize="48"
                                   Glyph="&#xE710;" />
                     </Button>
                     <StackPanel Grid.Row="1"
@@ -938,6 +943,24 @@
                     </StackPanel>
                 </Grid>
             </Button>
+            <Grid x:Name="ImportDropIndicator"
+                  IsHitTestVisible="False"
+                  Opacity="0">
+                <Grid.OpacityTransition>
+                    <ScalarTransition Duration="0:0:.18" />
+                </Grid.OpacityTransition>
+                <Border Margin="3"
+                        Background="{ThemeResource AccentFillColorDefaultBrush}"
+                        CornerRadius="17"
+                        Opacity=".08" />
+                <Rectangle Margin="2"
+                           RadiusX="18"
+                           RadiusY="18"
+                           Stroke="{ThemeResource AccentColor}"
+                           StrokeDashArray="1,2"
+                           StrokeDashCap="Round"
+                           StrokeThickness="3" />
+            </Grid>
         </Grid>
         <Button x:Name="OpenPluginCatalogBottomLeftButton"
                 Grid.Column="0"

--- a/CollapseLauncher/XAMLs/MainApp/Pages/PluginManagerPage.xaml.cs
+++ b/CollapseLauncher/XAMLs/MainApp/Pages/PluginManagerPage.xaml.cs
@@ -13,6 +13,10 @@ using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Windows.ApplicationModel.DataTransfer;
+using Windows.Foundation;
+using Windows.Graphics;
+using Windows.Storage;
 // ReSharper disable CheckNamespace
 
 #nullable enable
@@ -23,10 +27,36 @@ namespace CollapseLauncher.Pages
         public static PluginManagerPageContext Context { get; }              = new();
         public static PluginManagerPage        This    { get; private set; } = null!;
 
+        private readonly DispatcherTimer _fileDragIndicatorTimer = new()
+        {
+            Interval = TimeSpan.FromMilliseconds(50)
+        };
+        private bool _isWinUiFileDragActive;
+        private bool _isDropIndicatorVisible;
+
         public PluginManagerPage()
         {
             This = this;
             InitializeComponent();
+            _fileDragIndicatorTimer.Tick += OnFileDragIndicatorTimerTick;
+            Loaded += OnPluginManagerPageLoaded;
+            Unloaded += OnPluginManagerPageUnloaded;
+        }
+
+        private void OnPluginManagerPageLoaded(object sender, RoutedEventArgs e)
+        {
+            WindowUtility.FileDropEvent += OnNativeFileDrop;
+            WindowUtility.SetFileDropEnabled(true);
+            _fileDragIndicatorTimer.Start();
+        }
+
+        private void OnPluginManagerPageUnloaded(object sender, RoutedEventArgs e)
+        {
+            _fileDragIndicatorTimer.Stop();
+            _isWinUiFileDragActive = false;
+            SetImportDropIndicator(false);
+            WindowUtility.SetFileDropEnabled(false);
+            WindowUtility.FileDropEvent -= OnNativeFileDrop;
         }
 
         private void OnListViewRightClickUpdate(object sender, RightTappedRoutedEventArgs e)
@@ -63,10 +93,8 @@ namespace CollapseLauncher.Pages
 
         private async void OnClickImportButton(object sender, RoutedEventArgs e)
         {
-            int imported = 0;
             try
             {
-                ImportBoxButton.IsEnabled = false;
                 Dictionary<string, string> supportedFiles = new()
                 {
                     { Locale.Current.Lang?._PluginManagerPage?.FileDialogFileFilter1 ?? "", "*.zip;manifest.json" }
@@ -79,6 +107,117 @@ namespace CollapseLauncher.Pages
                     return;
                 }
 
+                await ImportPlugins(selectedFiles);
+            }
+            catch (Exception ex)
+            {
+                ErrorSender.SendException(ex.WrapPluginException("No plugin has been imported due to following error:"));
+            }
+        }
+
+        private void OnDragEnterImportBox(object sender, DragEventArgs e)
+        {
+            if (ImportBoxButton.IsEnabled && e.DataView.Contains(StandardDataFormats.StorageItems))
+            {
+                _isWinUiFileDragActive = true;
+                SetImportDropIndicator(true);
+                e.AcceptedOperation = DataPackageOperation.Copy;
+            }
+        }
+
+        private void OnDragLeaveImportBox(object sender, DragEventArgs e)
+        {
+            Point position = e.GetPosition(ImportBoxButton);
+            if (position.X >= 0 && position.X <= ImportBoxButton.ActualWidth &&
+                position.Y >= 0 && position.Y <= ImportBoxButton.ActualHeight)
+            {
+                return;
+            }
+
+            _isWinUiFileDragActive = false;
+            SetImportDropIndicator(false);
+        }
+
+        private void OnDragOverImportBox(object sender, DragEventArgs e)
+        {
+            if (ImportBoxButton.IsEnabled && e.DataView.Contains(StandardDataFormats.StorageItems))
+            {
+                _isWinUiFileDragActive = true;
+                SetImportDropIndicator(true);
+                e.AcceptedOperation = DataPackageOperation.Copy;
+            }
+        }
+
+        private async void OnDropImportBox(object sender, DragEventArgs e)
+        {
+            _isWinUiFileDragActive = false;
+            SetImportDropIndicator(false);
+            try
+            {
+                IReadOnlyList<IStorageItem> storageItems = await e.DataView.GetStorageItemsAsync();
+                string[] selectedFiles = storageItems.OfType<StorageFile>().Select(file => file.Path).ToArray();
+                await ImportPlugins(selectedFiles);
+            }
+            catch (Exception ex)
+            {
+                ErrorSender.SendException(ex.WrapPluginException("No plugin has been imported due to following error:"));
+            }
+        }
+
+        private async void OnNativeFileDrop(string[] selectedFiles, PointInt32 dropPoint)
+        {
+            if (!IsPointInDropArea(dropPoint))
+            {
+                return;
+            }
+
+            await ImportPlugins(selectedFiles);
+        }
+
+        private void OnFileDragIndicatorTimerTick(object? sender, object e)
+        {
+            bool isExternalDragOverDropArea =
+                WindowUtility.TryGetExternalDragPosition(out PointInt32 dragPosition) &&
+                IsPointInDropArea(dragPosition);
+            SetImportDropIndicator(_isWinUiFileDragActive || isExternalDragOverDropArea);
+        }
+
+        private bool IsPointInDropArea(PointInt32 point)
+        {
+            Rect dropAreaBounds = ImportBoxButton.TransformToVisual(null)
+                                                     .TransformBounds(new Rect(0,
+                                                                               0,
+                                                                               ImportBoxButton.ActualWidth,
+                                                                               ImportBoxButton.ActualHeight));
+            double scaleFactor = WindowUtility.CurrentWindowMonitorScaleFactor;
+            return point.X >= dropAreaBounds.Left * scaleFactor &&
+                   point.X <= dropAreaBounds.Right * scaleFactor &&
+                   point.Y >= dropAreaBounds.Top * scaleFactor &&
+                   point.Y <= dropAreaBounds.Bottom * scaleFactor;
+        }
+
+        private void SetImportDropIndicator(bool isVisible)
+        {
+            if (_isDropIndicatorVisible == isVisible)
+            {
+                return;
+            }
+
+            _isDropIndicatorVisible = isVisible;
+            ImportDropIndicator.Opacity = isVisible ? 1 : 0;
+        }
+
+        private async Task ImportPlugins(string[] selectedFiles)
+        {
+            if (selectedFiles.Length == 0)
+            {
+                return;
+            }
+
+            int imported = 0;
+            try
+            {
+                ImportBoxButton.IsEnabled = false;
                 List<Exception> exceptions = [];
 
                 foreach (string filePath in selectedFiles)

--- a/CollapseLauncher/XAMLs/MainApp/Pages/PluginManagerPage.xaml.cs
+++ b/CollapseLauncher/XAMLs/MainApp/Pages/PluginManagerPage.xaml.cs
@@ -1,5 +1,6 @@
 ﻿using CollapseLauncher.Dialogs;
 using CollapseLauncher.Helper;
+using CollapseLauncher.XAMLs.Theme.ContentDialog;
 using CollapseLauncher.Plugins;
 using Hi3Helper;
 using Hi3Helper.SentryHelper;
@@ -9,7 +10,9 @@ using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Input;
 using System;
 using System.Collections.Generic;
+using System.Data;
 using System.Diagnostics;
+using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -166,6 +169,9 @@ namespace CollapseLauncher.Pages
 
         private async void OnNativeFileDrop(string[] selectedFiles, PointInt32 dropPoint)
         {
+            _isWinUiFileDragActive = false;
+            SetImportDropIndicator(false);
+
             if (!IsPointInDropArea(dropPoint))
             {
                 return;
@@ -215,10 +221,10 @@ namespace CollapseLauncher.Pages
             }
 
             int imported = 0;
+            List<(string FilePath, Exception Exception)> failures = [];
             try
             {
                 ImportBoxButton.IsEnabled = false;
-                List<Exception> exceptions = [];
 
                 foreach (string filePath in selectedFiles)
                 {
@@ -230,27 +236,52 @@ namespace CollapseLauncher.Pages
                     }
                     catch (Exception exception)
                     {
-                        exceptions.Add(exception);
+                        failures.Add((filePath, exception));
+                        Logger.LogWriteLine($"[PluginManagerPage::ImportPlugins] Failed to import: {filePath}\r\n{exception}",
+                                            LogType.Error,
+                                            true);
                     }
                 }
-
-                if (exceptions.Count > 0)
-                {
-                    throw new AggregateException(exceptions);
-                }
-            }
-            catch (Exception ex)
-            {
-                string messageHead = imported > 0 ?
-                    $"{imported} plugin(s) have been imported! But some error has occurred while importing other plugins:" :
-                    "No plugin has been imported due to following error:";
-
-                ErrorSender.SendException(ex.WrapPluginException(messageHead));
             }
             finally
             {
                 ImportBoxButton.IsEnabled = true;
             }
+
+            if (failures.Count == 0)
+            {
+                return;
+            }
+
+            string messageHead = imported > 0 ?
+                $"{imported} plugin(s) were imported, but {failures.Count} file(s) could not be imported:" :
+                "No plugins were imported:";
+            string failureMessages = string.Join(Environment.NewLine,
+                                                 failures.Select(failure =>
+                                                     $"- {Path.GetFileName(failure.FilePath)}: {GetFriendlyImportError(failure.FilePath, failure.Exception)}"));
+
+            string warningMessage = $"{messageHead}{Environment.NewLine}{Environment.NewLine}{failureMessages}";
+            await SimpleDialogs.SpawnDialog(Locale.Current.Lang?._UnhandledExceptionPage?.UnhandledTitle4 ?? "Warning",
+                                            warningMessage,
+                                            ImportBoxButton,
+                                            Locale.Current.Lang?._Misc?.Close,
+                                            dialogTheme: ContentDialogTheme.Warning);
+        }
+
+        private static string GetFriendlyImportError(string filePath, Exception exception)
+        {
+            return exception switch
+            {
+                NotSupportedException        => exception.Message,
+                DuplicateNameException      => exception.Message,
+                UnauthorizedAccessException => "Permission was denied while reading or installing the plugin.",
+                FileNotFoundException       => "The package is missing its manifest or another required file.",
+                InvalidDataException        => "The archive or manifest is invalid.",
+                IOException when filePath.EndsWith(".zip", StringComparison.OrdinalIgnoreCase) =>
+                    "The archive could not be read or installed.",
+                IOException => "The manifest or one of its referenced files could not be read.",
+                _ => "The file is not a valid or supported plugin."
+            };
         }
 
         internal static async void AskLauncherRestart(object? sender, RoutedEventArgs? e)

--- a/CollapseLauncher/XAMLs/MainApp/Pages/PluginManagerPage.xaml.cs
+++ b/CollapseLauncher/XAMLs/MainApp/Pages/PluginManagerPage.xaml.cs
@@ -3,6 +3,7 @@ using CollapseLauncher.Helper;
 using CollapseLauncher.XAMLs.Theme.ContentDialog;
 using CollapseLauncher.Plugins;
 using Hi3Helper;
+using Hi3Helper.LocaleSourceGen;
 using Hi3Helper.SentryHelper;
 using Hi3Helper.Win32.FileDialogCOM;
 using Microsoft.UI.Xaml;
@@ -114,7 +115,7 @@ namespace CollapseLauncher.Pages
             }
             catch (Exception ex)
             {
-                ErrorSender.SendException(ex.WrapPluginException("No plugin has been imported due to following error:"));
+                ErrorSender.SendException(ex.WrapPluginException(Locale.Current.Lang?._PluginManagerPage?.Error_NoPluginImported));
             }
         }
 
@@ -153,31 +154,39 @@ namespace CollapseLauncher.Pages
 
         private async void OnDropImportBox(object sender, DragEventArgs e)
         {
-            _isWinUiFileDragActive = false;
-            SetImportDropIndicator(false);
             try
             {
+                _isWinUiFileDragActive = false;
+                SetImportDropIndicator(false);
+
                 IReadOnlyList<IStorageItem> storageItems = await e.DataView.GetStorageItemsAsync();
-                string[] selectedFiles = storageItems.OfType<StorageFile>().Select(file => file.Path).ToArray();
+                string[] selectedFiles = [.. storageItems.OfType<StorageFile>().Select(file => file.Path)];
                 await ImportPlugins(selectedFiles);
             }
             catch (Exception ex)
             {
-                ErrorSender.SendException(ex.WrapPluginException("No plugin has been imported due to following error:"));
+                ErrorSender.SendException(ex.WrapPluginException(Locale.Current.Lang?._PluginManagerPage?.Error_NoPluginImported));
             }
         }
 
         private async void OnNativeFileDrop(string[] selectedFiles, PointInt32 dropPoint)
         {
-            _isWinUiFileDragActive = false;
-            SetImportDropIndicator(false);
-
-            if (!IsPointInDropArea(dropPoint))
+            try
             {
-                return;
-            }
+                _isWinUiFileDragActive = false;
+                SetImportDropIndicator(false);
 
-            await ImportPlugins(selectedFiles);
+                if (!IsPointInDropArea(dropPoint))
+                {
+                    return;
+                }
+
+                await ImportPlugins(selectedFiles);
+            }
+            catch (Exception ex)
+            {
+                ErrorSender.SendException(ex);
+            }
         }
 
         private void OnFileDragIndicatorTimerTick(object? sender, object e)
@@ -268,19 +277,21 @@ namespace CollapseLauncher.Pages
                                             dialogTheme: ContentDialogTheme.Warning);
         }
 
-        private static string GetFriendlyImportError(string filePath, Exception exception)
+        private static string? GetFriendlyImportError(string filePath, Exception exception)
         {
+            LangParamsPluginManagerPage? locale    = Locale.Current.Lang?._PluginManagerPage;
+            bool                         isFileZip = filePath.EndsWith(".zip", StringComparison.OrdinalIgnoreCase);
+
             return exception switch
             {
-                NotSupportedException        => exception.Message,
+                NotSupportedException       => exception.Message,
                 DuplicateNameException      => exception.Message,
-                UnauthorizedAccessException => "Permission was denied while reading or installing the plugin.",
-                FileNotFoundException       => "The package is missing its manifest or another required file.",
-                InvalidDataException        => "The archive or manifest is invalid.",
-                IOException when filePath.EndsWith(".zip", StringComparison.OrdinalIgnoreCase) =>
-                    "The archive could not be read or installed.",
-                IOException => "The manifest or one of its referenced files could not be read.",
-                _ => "The file is not a valid or supported plugin."
+                UnauthorizedAccessException => locale?.Error_AccessDeniedPluginInstall,
+                FileNotFoundException       => locale?.Error_PluginPackageMissingManifest,
+                InvalidDataException        => locale?.Error_PluginPackageInvalidManifest,
+                IOException when isFileZip  => locale?.Error_IOErrorCannotBeInstalled,
+                IOException                 => locale?.Error_IOErrorCannotBeRead,
+                _                           => locale?.Error_PluginNotSupportedOrInvalid
             };
         }
 

--- a/Hi3Helper.Core/Lang/en_US.json
+++ b/Hi3Helper.Core/Lang/en_US.json
@@ -837,10 +837,10 @@
     "ListViewFooterWarning1": "You need to restart your launcher in order to apply the changes!",
     "ListViewFooterRestartButton": "Restart the Launcher",
 
-    "RightPanelImportTitle1": "Click to add the",
+    "RightPanelImportTitle1": "Browse or drop a",
     "RightPanelImportTitle2": "or",
-    "RightPanelImportTitle3": "here",
-    "RightPanelImportTitle4": "Anywhere in the box is fine!"
+    "RightPanelImportTitle3": "",
+    "RightPanelImportTitle4": "Drop plugin files anywhere in this panel"
   },
 
   "_Misc": {

--- a/Hi3Helper.Core/Lang/en_US.json
+++ b/Hi3Helper.Core/Lang/en_US.json
@@ -837,10 +837,18 @@
     "ListViewFooterWarning1": "You need to restart your launcher in order to apply the changes!",
     "ListViewFooterRestartButton": "Restart the Launcher",
 
-    "RightPanelImportTitle1": "Browse or drop a",
+    "RightPanelImportTitle1": "Click to Browse or drop a",
     "RightPanelImportTitle2": "or",
     "RightPanelImportTitle3": "",
-    "RightPanelImportTitle4": "Drop plugin files anywhere in this panel"
+    "RightPanelImportTitle4": "Drop plugin files anywhere in this panel",
+
+    "Error_NoPluginImported": "No plugin has been imported due to following error:",
+    "Error_AccessDeniedPluginInstall": "Permission was denied while reading or installing the plugin.",
+    "Error_PluginPackageMissingManifest": "The package is missing its manifest or another required file.",
+    "Error_PluginPackageInvalidManifest": "The archive or manifest is invalid.",
+    "Error_IOErrorCannotBeInstalled": "The archive could not be read or installed.",
+    "Error_IOErrorCannotBeRead": "The manifest or one of its referenced files could not be read.",
+    "Error_PluginNotSupportedOrInvalid": "The file is not a valid or supported plugin."
   },
 
   "_Misc": {


### PR DESCRIPTION
# Main Goal
Add drag-and-drop plugin importing to `PluginManagerPage`, including support for dragging files from unelevated Windows Explorer into Collapse’s elevated process, while retaining the existing file-picker workflow.

## PR Status :

- Overall Status : Done
- Commits : Done
- Synced to base (Collapse:main) : Yes
- Build status : OK
- Crashing : No
- Bug found caused by PR : 0

### Changelog

**[New]** Added drag-and-drop plugin importing to `PluginManagerPage`.

- Enabled dropping on `ImportBoxButton` through `AllowDrop="True"` and the following XAML handlers:
  - `OnDragEnterImportBox`
  - `OnDragOverImportBox`
  - `OnDragLeaveImportBox`
  - `OnDropImportBox`
- `OnDropImportBox` retrieves `StorageFile` objects from `DragEventArgs.DataView.GetStorageItemsAsync()` and converts them into file-system paths.
- Supports dropping multiple plugin files in one operation.
- Dropped `.zip` packages and `manifest.json` files are passed to the same `ImportPlugins` method used by the existing file picker.
- `ImportPlugins` calls `PluginImporter.AutoGetImportFromPath` for each path and adds successfully imported `PluginInfo` objects to `PluginManagerPage.Context.PluginCollection`.
- Individual import failures are collected and reported together through `AggregateException` and `ErrorSender.SendException`.
- The import panel remains disabled while `ImportPlugins` is running, preventing overlapping imports.

**[New]** Added elevated-process file-drop support to `WindowUtility`.

- Collapse uses `requireAdministrator`, which prevents normal Explorer drag events from reaching the WinUI drop target because Explorer usually runs at a lower integrity level.
- Added `WindowUtility.SetFileDropEnabled` to register the main window with the native `DragAcceptFiles` API.
- `SetFileDropEnabled` uses `ChangeWindowMessageFilterEx` to permit the native messages required for cross-integrity shell drops:
  - `WM_DROPFILES`
  - `WM_COPYDATA`
  - `WM_COPYGLOBALDATA`
- Extended `WindowUtility.MainWndProc` to process `WM_DROPFILES` and forward its `HDROP` handle to `HandleFileDrop`.
- `HandleFileDrop` uses:
  - `DragQueryFile` to retrieve every dropped path.
  - `DragQueryPoint` to retrieve the drop coordinates.
  - `DragFinish` to release the native `HDROP` handle.
- Added `WindowUtility.FileDropEvent`, which passes the collected paths and drop coordinates to `PluginManagerPage.OnNativeFileDrop`.
- `PluginManagerPage.OnPluginManagerPageLoaded` enables native file drops and subscribes to `FileDropEvent`.
- `OnPluginManagerPageUnloaded` disables native file drops and removes the event subscription.
- `OnNativeFileDrop` calls `IsPointInDropArea` so native drops are accepted only when they occur inside `ImportBoxButton`.

**[Imp]** Refactored the existing plugin import workflow.

- `OnClickImportButton` remains responsible for opening `FileDialogNative.GetMultiFilePicker`.
- The picker’s import loop was extracted into `ImportPlugins`.
- Both `OnClickImportButton` and `OnDropImportBox` now call `ImportPlugins`, keeping validation, collection updates, partial-success handling, and error reporting consistent between both input methods.
- Existing picker filters remain limited to `.zip` and `manifest.json`.

**[Imp]** Added drag-hover feedback for both WinUI and elevated Explorer drops.

- Added the `ImportDropIndicator` overlay directly above the plugin import panel.
- The overlay contains:
  - A rounded `Rectangle` with `StrokeDashArray="1,2"` and `StrokeDashCap="Round"`.
  - A three-pixel dotted outline using the palette-driven `AccentColor` theme resource.
  - A subtle background fill using `AccentFillColorDefaultBrush`.
- Added a `ScalarTransition` with a duration of 180 ms to fade the indicator in and out.
- `SetImportDropIndicator` tracks the current visibility state and changes the overlay opacity only when necessary.
- Standard WinUI drag events update `_isWinUiFileDragActive` and call `SetImportDropIndicator`.
- Native `WM_DROPFILES` does not provide drag-enter or drag-leave notifications, so `PluginManagerPage` uses `_fileDragIndicatorTimer` to detect elevated Explorer hover state.
- `OnFileDragIndicatorTimerTick` calls `WindowUtility.TryGetExternalDragPosition` every 50 ms.
- `TryGetExternalDragPosition` uses:
  - `GetAsyncKeyState` to detect left- or right-button dragging.
  - `GetCursorPos` to obtain the global pointer position.
  - `ScreenToClient` to convert it into launcher client coordinates.
  - `GetForegroundWindow` to avoid treating normal clicks inside Collapse as external drags.
- `IsPointInDropArea` compares the native pointer coordinates against the transformed bounds of `ImportBoxButton`, including the current monitor scale factor.

- **[Loc]** Updated the English plugin-import instructions.

### Templates

<details>
  <summary>Changelog Prefixes</summary>
  
  ```
    **[New]**
    **[Imp]**
    **[Fix]**
    **[Loc]**
    **[Doc]**
  ```

</details>
