### PR TITLE
Cache background URLs for instant background on game switch

### DIFF
--- a/CollapseLauncher/Classes/Extension/UIElementExtensions.ThemeExtensions.cs
+++ b/CollapseLauncher/Classes/Extension/UIElementExtensions.ThemeExtensions.cs
@@ -15,6 +15,13 @@ namespace CollapseLauncher.Extension
 
         public static void ChangeAccentColor(this FrameworkElement element, Color baseColor)
         {
+            if (Application.Current.Resources.TryGetValue("AccentColor", out object? existing) &&
+                existing is SolidColorBrush existingBrush &&
+                existingBrush.Color.Equals(baseColor))
+            {
+                return;
+            }
+
             Color accentColorMask        = baseColor;
             Color accentColorTransparent = baseColor;
 
@@ -55,30 +62,28 @@ namespace CollapseLauncher.Extension
 
         internal static void ReloadPageTheme(this FrameworkElement page)
         {
-            ElementTheme theme = InnerLauncherConfig.CurrentAppTheme switch
+            ElementTheme target = InnerLauncherConfig.CurrentAppTheme switch
                                  {
                                      AppThemeMode.Dark => ElementTheme.Dark,
                                      AppThemeMode.Light => ElementTheme.Light,
                                      _ => ElementTheme.Default
                                  };
 
+            // Force the opposite theme first to ensure ThemeResource re-evaluation.
+            ElementTheme opposite = target switch
+            {
+                ElementTheme.Dark  => ElementTheme.Light,
+                ElementTheme.Light => ElementTheme.Dark,
+                _                  => ElementTheme.Light
+            };
+
             bool isComplete = false;
             while (!isComplete)
             {
                 try
                 {
-                    page.RequestedTheme = page.RequestedTheme switch
-                                          {
-                                              ElementTheme.Dark => ElementTheme.Light,
-                                              ElementTheme.Light => ElementTheme.Default,
-                                              ElementTheme.Default => ElementTheme.Dark,
-                                              _ => page.RequestedTheme
-                                          };
-
-                    if (page.RequestedTheme != theme)
-                    {
-                        ReloadPageTheme(page);
-                    }
+                    page.RequestedTheme = opposite;
+                    page.RequestedTheme = target;
 
                     isComplete = true;
                 }

--- a/CollapseLauncher/Classes/Extension/UIElementExtensions.cs
+++ b/CollapseLauncher/Classes/Extension/UIElementExtensions.cs
@@ -543,9 +543,6 @@ namespace CollapseLauncher.Extension
 
         internal static void SetApplicationResource(string resourceKey, object value)
         {
-            if (!CurrentResourceDictionary.ContainsKey(resourceKey))
-                throw new KeyNotFoundException($"Application resource with key: {resourceKey} does not exist!");
-
             CurrentResourceDictionary[resourceKey] = value;
         }
 

--- a/CollapseLauncher/Classes/GameManagement/ImageBackground/ImageBackgroundManager.Control.cs
+++ b/CollapseLauncher/Classes/GameManagement/ImageBackground/ImageBackgroundManager.Control.cs
@@ -58,7 +58,7 @@ public partial class ImageBackgroundManager
         bool                           hasStaticImage = !string.IsNullOrEmpty(context?.BackgroundImageStaticPath);
         if (isUserRequest && hasStaticImage && context != null)
         {
-            LoadImageAtIndex(CurrentSelectedBackgroundIndex, false, CancellationToken.None);
+            LoadImageAtIndex(CurrentSelectedBackgroundIndex, false, CancellationToken.None, true);
         }
 
         // Force to restore autoplay status to true.
@@ -81,7 +81,7 @@ public partial class ImageBackgroundManager
         bool                           hasStaticImage = !string.IsNullOrEmpty(context?.BackgroundImageStaticPath);
         if (isUserRequest && hasStaticImage && context != null)
         {
-            LoadImageAtIndex(CurrentSelectedBackgroundIndex, true, CancellationToken.None);
+            LoadImageAtIndex(CurrentSelectedBackgroundIndex, true, CancellationToken.None, true);
             return;
         }
 

--- a/CollapseLauncher/Classes/GameManagement/ImageBackground/ImageBackgroundManager.Loaders.cs
+++ b/CollapseLauncher/Classes/GameManagement/ImageBackground/ImageBackgroundManager.Loaders.cs
@@ -181,7 +181,6 @@ public partial class ImageBackgroundManager
             ImageSource = new BitmapImage(new Uri(placeholderPath)),
             Stretch     = Stretch.UniformToFill
         };
-        PresenterGrid.Children.Clear();
         CurrentBackgroundElement = null;
         _displayedContext = null;
         IsBackgroundLoading = true;

--- a/CollapseLauncher/Classes/GameManagement/ImageBackground/ImageBackgroundManager.Loaders.cs
+++ b/CollapseLauncher/Classes/GameManagement/ImageBackground/ImageBackgroundManager.Loaders.cs
@@ -138,7 +138,7 @@ public partial class ImageBackgroundManager
                                          && localStatic != null;
                 Uri accentPreviewUri = willDisplayStatic ? new Uri(localStatic!) : new Uri(localBackground);
 
-                RestoreSavedAccent(cachedBgKey, accentPreviewUri);
+                _ = RestoreSavedAccent(cachedBgKey, accentPreviewUri);
 
                 ImageContextSources.Clear();
                 ImageContextSources.Add(context);
@@ -361,7 +361,7 @@ public partial class ImageBackgroundManager
         CurrentBackgroundElement = CreateLayerElement(overlayFilePath, backgroundFilePath, backgroundStaticFilePath, context, isVideo);
     }
 
-    private void RestoreSavedAccent(string cachedBgKey, Uri? fallbackSourceUri = null)
+    private async Task RestoreSavedAccent(string cachedBgKey, Uri? fallbackSourceUri = null)
     {
         string? savedHex = LauncherConfig.GetAppConfigValue($"{cachedBgKey}-AccentColor").ToString();
         if (!string.IsNullOrEmpty(savedHex) && savedHex!.Length >= 6 && ThemeRootElement != null)
@@ -377,9 +377,7 @@ public partial class ImageBackgroundManager
         {
             try
             {
-                Color syncColor = Task.Run(async () =>
-                    await ColorPaletteUtility.GetMediaAccentColorFromAsync(fallbackSourceUri, false)
-                ).GetAwaiter().GetResult();
+                Color syncColor = await ColorPaletteUtility.GetMediaAccentColorFromAsync(fallbackSourceUri, false);
                 ThemeRootElement.ChangeAccentColor(syncColor);
                 LauncherConfig.SetAndSaveConfigValue($"{cachedBgKey}-AccentColor",
                     $"{syncColor.R:X2}{syncColor.G:X2}{syncColor.B:X2}");

--- a/CollapseLauncher/Classes/GameManagement/ImageBackground/ImageBackgroundManager.Loaders.cs
+++ b/CollapseLauncher/Classes/GameManagement/ImageBackground/ImageBackgroundManager.Loaders.cs
@@ -102,7 +102,11 @@ public partial class ImageBackgroundManager
         string? staticBgUrl      = LauncherConfig.GetAppConfigValue($"{cachedBgKey}-StaticBackground").ToString();
         string? overlayUrl       = LauncherConfig.GetAppConfigValue($"{cachedBgKey}-Overlay").ToString();
 
-        if (string.IsNullOrEmpty(backgroundUrl) && string.IsNullOrEmpty(staticBgUrl)) return;
+        if (string.IsNullOrEmpty(backgroundUrl) && string.IsNullOrEmpty(staticBgUrl))
+        {
+            IsBackgroundLoading = true;
+            return;
+        }
 
         string? primaryBg = backgroundUrl ?? staticBgUrl;
 
@@ -508,8 +512,14 @@ public partial class ImageBackgroundManager
             foreach (UIElement oldElement in toRemove)
             {
                 if (oldElement is LayeredBackgroundImage oldLayer)
+                {
                     oldLayer.ImageLoaded -= LayerElementOnLoaded;
-                PresenterGrid.Children.Remove(oldElement);
+                    oldLayer.Visibility = Visibility.Collapsed;
+                }
+                else
+                {
+                    PresenterGrid.Children.Remove(oldElement);
+                }
             }
 
             PresenterGrid.Background = null;

--- a/CollapseLauncher/Classes/GameManagement/ImageBackground/ImageBackgroundManager.Loaders.cs
+++ b/CollapseLauncher/Classes/GameManagement/ImageBackground/ImageBackgroundManager.Loaders.cs
@@ -355,13 +355,35 @@ public partial class ImageBackgroundManager
 
         if (!forceReload &&
             CurrentBackgroundElement != null &&
-            _displayedContext != null &&
-            context.Equals(_displayedContext))
+            _displayedContext != null)
         {
-            return;
+            if (context.Equals(_displayedContext))
+            {
+                return;
+            }
+
+            if (CurrentBackgroundElement is LayeredBackgroundImage existingLayer &&
+                IsSameLocalFile(existingLayer.BackgroundSource, backgroundFilePath) &&
+                IsSameLocalFile(existingLayer.BackgroundStaticSource, backgroundStaticFilePath))
+            {
+                return;
+            }
         }
 
         CurrentBackgroundElement = CreateLayerElement(overlayFilePath, backgroundFilePath, backgroundStaticFilePath, context, isVideo);
+    }
+
+    private static bool IsSameLocalFile(object? currentSource, Uri? newFilePath)
+    {
+        if (newFilePath == null) return currentSource == null;
+        string? newPath = newFilePath.IsFile ? newFilePath.LocalPath : newFilePath.OriginalString;
+        string? currentPath = currentSource switch
+        {
+            Uri uri => uri.IsFile ? uri.LocalPath : uri.OriginalString,
+            string str => str,
+            _ => null
+        };
+        return string.Equals(currentPath, newPath, StringComparison.OrdinalIgnoreCase);
     }
 
     private async Task RestoreSavedAccent(string cachedBgKey, Uri? fallbackSourceUri = null)
@@ -511,8 +533,22 @@ public partial class ImageBackgroundManager
             foreach (UIElement oldElement in toRemove)
             {
                 if (oldElement is LayeredBackgroundImage oldLayer)
+                {
                     oldLayer.ImageLoaded -= LayerElementOnLoaded;
-                PresenterGrid.Children.Remove(oldElement);
+
+                    if (oldLayer.Tag == null)
+                    {
+                        oldLayer.Opacity = 0;
+                    }
+                    else
+                    {
+                        PresenterGrid.Children.Remove(oldElement);
+                    }
+                }
+                else
+                {
+                    PresenterGrid.Children.Remove(oldElement);
+                }
             }
 
             PresenterGrid.Background = null;

--- a/CollapseLauncher/Classes/GameManagement/ImageBackground/ImageBackgroundManager.Loaders.cs
+++ b/CollapseLauncher/Classes/GameManagement/ImageBackground/ImageBackgroundManager.Loaders.cs
@@ -511,14 +511,8 @@ public partial class ImageBackgroundManager
             foreach (UIElement oldElement in toRemove)
             {
                 if (oldElement is LayeredBackgroundImage oldLayer)
-                {
                     oldLayer.ImageLoaded -= LayerElementOnLoaded;
-                    oldLayer.Visibility = Visibility.Collapsed;
-                }
-                else
-                {
-                    PresenterGrid.Children.Remove(oldElement);
-                }
+                PresenterGrid.Children.Remove(oldElement);
             }
 
             PresenterGrid.Background = null;

--- a/CollapseLauncher/Classes/GameManagement/ImageBackground/ImageBackgroundManager.Loaders.cs
+++ b/CollapseLauncher/Classes/GameManagement/ImageBackground/ImageBackgroundManager.Loaders.cs
@@ -2,6 +2,7 @@
 using CollapseLauncher.Helper;
 using CollapseLauncher.Helper.Background;
 using CollapseLauncher.Helper.Image;
+using CollapseLauncher.Helper.Metadata;
 using CollapseLauncher.Helper.StreamUtility;
 using CollapseLauncher.Pages;
 using CollapseLauncher.XAMLs.Theme.CustomControls;
@@ -9,13 +10,18 @@ using Hi3Helper;
 using Hi3Helper.SentryHelper;
 using Hi3Helper.Shared.Region;
 using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Data;
+using Microsoft.UI.Xaml.Media;
 using Microsoft.UI.Xaml.Media.Animation;
+using Microsoft.UI.Xaml.Media.Imaging;
 using PhotoSauce.MagicScaler;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Globalization;
 using System.IO;
+using System.Runtime.InteropServices;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading;
@@ -35,7 +41,7 @@ public partial class ImageBackgroundManager
 
     #endregion
 
-    private void LoadImageAtIndex(int index, bool forceLoadToStatic, CancellationToken token)
+    private void LoadImageAtIndex(int index, bool forceLoadToStatic, CancellationToken token, bool forceReload = false)
     {
         if (ImageContextSources.Count <= index ||
             index < 0)
@@ -48,12 +54,16 @@ public partial class ImageBackgroundManager
             CancelCurrentBackgroundLoad();
         }
 
-        IsBackgroundLoading = true;
+        // Only show loading indicator when a download is required.
+        if (!CheckIsContextCached(ImageContextSources[index]))
+        {
+            IsBackgroundLoading = true;
+        }
         new Thread(async void () =>
         {
             try
             {
-                await LoadImageAtIndexCore(index, forceLoadToStatic, token).ConfigureAwait(false);
+                await LoadImageAtIndexCore(index, forceLoadToStatic, token, forceReload).ConfigureAwait(false);
             }
             catch (Exception e)
             {
@@ -76,7 +86,103 @@ public partial class ImageBackgroundManager
         IsBackgroundLoading = false;
     }
 
-    private async Task LoadImageAtIndexCore(int index, bool forceLoadToStatic, CancellationToken token)
+    public void PreloadBackground(PresetConfig? preset, Grid? presenterGrid)
+    {
+        if (preset == null || presenterGrid == null) return;
+
+        CancelCurrentBackgroundLoad();
+        Interlocked.Increment(ref _loadGeneration);
+
+        PresenterGrid = presenterGrid;
+        string autoPlayKey = $"LastIsEnableBackgroundAutoPlay-{preset.GameName}-{preset.ZoneName}";
+        CurrentIsEnableBackgroundAutoPlayKey = autoPlayKey;
+
+        string cachedBgKey = $"CachedBg-{preset.GameName}-{preset.ZoneName}";
+        string? backgroundUrl    = LauncherConfig.GetAppConfigValue($"{cachedBgKey}-Background").ToString();
+        string? staticBgUrl      = LauncherConfig.GetAppConfigValue($"{cachedBgKey}-StaticBackground").ToString();
+        string? overlayUrl       = LauncherConfig.GetAppConfigValue($"{cachedBgKey}-Overlay").ToString();
+
+        if (string.IsNullOrEmpty(backgroundUrl) && string.IsNullOrEmpty(staticBgUrl)) return;
+
+        string? primaryBg = backgroundUrl ?? staticBgUrl;
+
+        LayeredImageBackgroundContext context = new()
+        {
+            OriginOverlayImagePath          = overlayUrl,
+            OriginBackgroundImagePath       = backgroundUrl,
+            OriginBackgroundStaticImagePath = staticBgUrl,
+            OverlayImagePath                = overlayUrl,
+            BackgroundImagePath             = primaryBg,
+            BackgroundImageStaticPath       = staticBgUrl,
+            IsVideo                         = IsVideoMediaFileExtensionSupported(primaryBg ?? staticBgUrl!),
+            IsCustom                        = false
+        };
+
+        if (CheckIsContextCached(context))
+        {
+            string? localOverlay    = TryGetCachedLocalPath(overlayUrl);
+            string? localBackground = TryGetCachedLocalPath(primaryBg);
+            string? localStatic     = TryGetCachedLocalPath(staticBgUrl);
+
+            bool overlayRequired  = !string.IsNullOrEmpty(overlayUrl);
+            bool staticRequired   = !string.IsNullOrEmpty(staticBgUrl);
+
+            if (localBackground != null &&
+                (!overlayRequired || localOverlay != null) &&
+                (!staticRequired  || localStatic != null))
+            {
+                bool willDisplayStatic = !IsVideoMediaFileExtensionSupported(primaryBg ?? staticBgUrl!) ||
+                                         (!CurrentIsEnableCustomImage &&
+                                          !GlobalIsEnableCustomImage &&
+                                          !CurrentIsEnableBackgroundAutoPlay);
+                Uri accentPreviewUri = willDisplayStatic ? new Uri(localStatic) : new Uri(localBackground);
+
+                RestoreSavedAccent(cachedBgKey, accentPreviewUri);
+
+                ImageContextSources.Clear();
+                ImageContextSources.Add(context);
+                OnPropertyChanged(nameof(CurrentSelectedBackgroundContext));
+                OnPropertyChanged(nameof(CurrentBackgroundCount));
+
+                CurrentBackgroundElement = CreateLayerElement(localOverlay != null ? new Uri(localOverlay) : null,
+                                                              new Uri(localBackground),
+                                                              localStatic != null ? new Uri(localStatic) : null,
+                                                              context,
+                                                              IsVideoMediaFileExtensionSupported(primaryBg ?? staticBgUrl!));
+
+                bool isUseFFmpeg = GlobalIsUseFFmpeg && GlobalIsFFmpegAvailable;
+                new Thread(async void (ctx) =>
+                {
+                    try
+                    {
+                        await GetMediaAccentColor(ctx).ConfigureAwait(false);
+                    }
+                    catch (Exception e)
+                    {
+                        Logger.LogWriteLine($"{e}", LogType.Error, true);
+                    }
+                })
+                {
+                    IsBackground = true
+                }.UnsafeStart((accentPreviewUri, isUseFFmpeg, cachedBgKey));
+                return;
+            }
+        }
+
+        // Show preset placeholder.
+        string placeholderPath = GetPlaceholderBackgroundImageFrom(null);
+        PresenterGrid.Background = new ImageBrush
+        {
+            ImageSource = new BitmapImage(new Uri(placeholderPath)),
+            Stretch     = Stretch.UniformToFill
+        };
+        PresenterGrid.Children.Clear();
+        CurrentBackgroundElement = null;
+        _displayedContext = null;
+        IsBackgroundLoading = true;
+    }
+
+    private async Task LoadImageAtIndexCore(int index, bool forceLoadToStatic, CancellationToken token, bool forceReload = false)
     {
         Stopwatch? stopwatch = null;
         try
@@ -126,8 +232,13 @@ public partial class ImageBackgroundManager
 
             // Try to use static bg URL if normal bg is not available.
             downloadedBackgroundUri ??= downloadedBackgroundStaticUri;
-            if (downloadedBackgroundUri == null) // If no background file is available, return.
+            if (downloadedBackgroundUri == null)
             {
+                if (!context.IsCustom)
+                {
+                    NeedFallbackPlaceholder = false;
+                    OnBackgroundLoadFailed?.Invoke();
+                }
                 return;
             }
 
@@ -148,7 +259,23 @@ public partial class ImageBackgroundManager
                 return;
             }
 
-            // -- Read Color Accent information from current background context.
+            // Try to force loading static image if requested.
+            if (forceLoadToStatic && downloadedBackgroundStaticUri != null)
+            {
+                isVideo                       = false;
+                downloadedBackgroundUri       = downloadedBackgroundStaticUri;
+                downloadedBackgroundStaticUri = null;
+            }
+
+            // Read accent color from the source that is actually displayed.
+            bool willDisplayStatic = !isVideo ||
+                                     (!CurrentIsEnableCustomImage &&
+                                      !GlobalIsEnableCustomImage &&
+                                      !CurrentIsEnableBackgroundAutoPlay);
+            Uri? accentSourceUri = willDisplayStatic
+                ? downloadedBackgroundStaticUri ?? downloadedBackgroundUri
+                : downloadedBackgroundUri;
+
             new Thread(async void (ctx) =>
             {
                 try
@@ -162,39 +289,50 @@ public partial class ImageBackgroundManager
             })
             {
                 IsBackground = true
-            }.UnsafeStart((downloadedBackgroundUri, isUseFFmpeg));
+            }.UnsafeStart((accentSourceUri, isUseFFmpeg, CurrentCachedBgKey));
 
-            // Try to force loading static image if requested.
-            if (forceLoadToStatic && downloadedBackgroundStaticUri != null)
+            if (!context.IsCustom &&
+                !string.IsNullOrEmpty(CurrentCachedBgKey))
             {
-                isVideo                       = false;
-                downloadedBackgroundUri       = downloadedBackgroundStaticUri;
-                downloadedBackgroundStaticUri = null;
+                LauncherConfig.SetAndSaveConfigValue($"{CurrentCachedBgKey}-Background",       context.OriginBackgroundImagePath ?? "");
+                LauncherConfig.SetAndSaveConfigValue($"{CurrentCachedBgKey}-StaticBackground", context.OriginBackgroundStaticImagePath ?? "");
+                LauncherConfig.SetAndSaveConfigValue($"{CurrentCachedBgKey}-Overlay",          context.OriginOverlayImagePath ?? "");
             }
 
             // -- Use UI thread and load image layer
+            int captureGen = _loadGeneration;
+            bool captureForceReload = forceReload;
             DispatcherQueueExtensions
                .CurrentDispatcherQueue
                .TryEnqueue(() => SpawnImageLayer(downloadedOverlayUri,
-                                                 downloadedBackgroundUri,
-                                                 downloadedBackgroundStaticUri,
-                                                 isVideo,
-                                                 context));
+                                                  downloadedBackgroundUri,
+                                                  downloadedBackgroundStaticUri,
+                                                  isVideo,
+                                                  context,
+                                                  captureGen,
+                                                  forceReload: captureForceReload));
 
             GlobalIsFFmpegCurrentlyUsed = isVideo && isUseFFmpeg;
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
             _ = SentryHelper.ExceptionHandlerAsync(ex);
             Logger.LogWriteLine($"[ImageBackgroundManager::LoadImageAtIndex] {ex}",
                                 LogType.Error,
                                 true);
         }
+        catch (OperationCanceledException)
+        {
+            // Suppress: cancellation is expected on game switch or rapid load cycles.
+        }
         finally
         {
             stopwatch?.Stop();
             Logger.LogWriteLine($"Background image loading took: {stopwatch?.Elapsed.TotalSeconds} second(s)");
-            IsBackgroundLoading = false;
+            if (!token.IsCancellationRequested)
+            {
+                IsBackgroundLoading = false;
+            }
         }
     }
 
@@ -202,14 +340,75 @@ public partial class ImageBackgroundManager
                                  Uri? backgroundFilePath,
                                  Uri? backgroundStaticFilePath,
                                  bool isVideo,
-                                 LayeredImageBackgroundContext context)
+                                 LayeredImageBackgroundContext context,
+                                 int loadGeneration,
+                                 bool forceReload = false)
     {
-        if (CurrentSelectedBackgroundContext != null &&
-            !context.Equals(CurrentSelectedBackgroundContext))
+        if (loadGeneration != _loadGeneration)
         {
             return;
         }
 
+        if (!forceReload &&
+            CurrentBackgroundElement != null &&
+            _displayedContext != null &&
+            context.Equals(_displayedContext))
+        {
+            return;
+        }
+
+        CurrentBackgroundElement = CreateLayerElement(overlayFilePath, backgroundFilePath, backgroundStaticFilePath, context, isVideo);
+    }
+
+    private void RestoreSavedAccent(string cachedBgKey, Uri? fallbackSourceUri = null)
+    {
+        string? savedHex = LauncherConfig.GetAppConfigValue($"{cachedBgKey}-AccentColor").ToString();
+        if (!string.IsNullOrEmpty(savedHex) && savedHex!.Length >= 6 && ThemeRootElement != null)
+        {
+            if (TryParseHexColor(savedHex, out Color accentColor))
+            {
+                ThemeRootElement.ChangeAccentColor(accentColor);
+                return;
+            }
+        }
+
+        if (fallbackSourceUri != null && ThemeRootElement != null)
+        {
+            try
+            {
+                Color syncColor = Task.Run(async () =>
+                    await ColorPaletteUtility.GetMediaAccentColorFromAsync(fallbackSourceUri, false)
+                ).GetAwaiter().GetResult();
+                ThemeRootElement.ChangeAccentColor(syncColor);
+                LauncherConfig.SetAndSaveConfigValue($"{cachedBgKey}-AccentColor",
+                    $"{syncColor.R:X2}{syncColor.G:X2}{syncColor.B:X2}");
+            }
+            catch (Exception ex)
+            {
+                Logger.LogWriteLine($"RestoreSavedAccent failed: {ex}", LogType.Error, true);
+            }
+        }
+    }
+
+    private static bool TryParseHexColor(string hex, out Color color)
+    {
+        color = default;
+        if (hex.Length < 6) return false;
+        if (hex[0] == '#')
+            hex = hex[1..];
+        if (!uint.TryParse(hex, NumberStyles.HexNumber, null, out uint argb)) return false;
+        if (hex.Length <= 6)
+            argb = 0xFF_000000 | argb;
+        color = Color.FromArgb((byte)(argb >> 24), (byte)(argb >> 16), (byte)(argb >> 8), (byte)argb);
+        return true;
+    }
+
+    private LayeredBackgroundImage CreateLayerElement(Uri? overlayFilePath,
+                                                      Uri? backgroundFilePath,
+                                                      Uri? backgroundStaticFilePath,
+                                                      LayeredImageBackgroundContext context,
+                                                      bool isVideo)
+    {
         LayeredBackgroundImage layerElement = new()
         {
             BackgroundSource          = backgroundFilePath,
@@ -220,8 +419,6 @@ public partial class ImageBackgroundManager
             ParallaxResetOnUnfocused  = false,
             BackgroundElevationPixels = 64d
         };
-
-        CurrentBackgroundElement = layerElement;
 
         if (!CurrentIsEnableCustomImage &&
             !GlobalIsEnableCustomImage)
@@ -293,10 +490,12 @@ public partial class ImageBackgroundManager
                                   bindingMode: BindingMode.OneWay,
                                   converter: StaticConverter<InverseBooleanConverter>.Shared);
 
-        layerElement.ImageLoaded       += LayerElementOnLoaded;
+        layerElement.ImageLoaded += LayerElementOnLoaded;
         PresenterGrid?.Children.Add(layerElement);
 
         layerElement.Tag = isVideo;
+        _displayedContext = context;
+        return layerElement;
     }
 
     private void LayerElementOnLoaded(LayeredBackgroundImage layerElement)
@@ -304,11 +503,17 @@ public partial class ImageBackgroundManager
         layerElement.ImageLoaded -= LayerElementOnLoaded;
         layerElement.Transitions.Add(new PopupThemeTransition());
 
-        UIElement? lastElement = PresenterGrid?.Children.LastOrDefault();
-        List<UIElement> elementToRemove = PresenterGrid?.Children.Where(element => element != lastElement).ToList() ?? [];
-        foreach (UIElement element in elementToRemove)
+        if (PresenterGrid != null)
         {
-            PresenterGrid?.Children.Remove(element);
+            List<UIElement> toRemove = PresenterGrid.Children.Where(element => element != layerElement).ToList();
+            foreach (UIElement oldElement in toRemove)
+            {
+                if (oldElement is LayeredBackgroundImage oldLayer)
+                    oldLayer.ImageLoaded -= LayerElementOnLoaded;
+                PresenterGrid.Children.Remove(oldElement);
+            }
+
+            PresenterGrid.Background = null;
         }
 
         if (CurrentIsEnableBackgroundAutoPlay && WindowUtility.CurrentWindowIsVisible)
@@ -393,20 +598,29 @@ public partial class ImageBackgroundManager
     {
         try
         {
-            if (context is not (Uri asUri, bool useFfmpegForVideo))
+            if (context is not (Uri asUri, bool useFfmpegForVideo, string configKey))
             {
                 return;
             }
 
             Color color = await ColorPaletteUtility.GetMediaAccentColorFromAsync(asUri, useFfmpegForVideo)
                                                    .ConfigureAwait(false);
+
+            if (color == default(Color)) return;
+
+            string hex = $"{color.R:X2}{color.G:X2}{color.B:X2}";
+            if (!string.IsNullOrEmpty(configKey))
+            {
+                string? savedHex = LauncherConfig.GetAppConfigValue($"{configKey}-AccentColor").ToString();
+                if (savedHex == hex) return;
+                LauncherConfig.SetAndSaveConfigValue($"{configKey}-AccentColor", hex);
+            }
+
             ColorAccentChanged?.Invoke(color);
         }
         catch (Exception ex)
         {
-            Logger.LogWriteLine($"An error has occurred while trying to get media accent color! {ex}",
-                                LogType.Error,
-                                true);
+            Logger.LogWriteLine($"GetMediaAccentColor failed: {ex}", LogType.Error, true);
             SentryHelper.ExceptionHandler(ex);
         }
     }

--- a/CollapseLauncher/Classes/GameManagement/ImageBackground/ImageBackgroundManager.Loaders.cs
+++ b/CollapseLauncher/Classes/GameManagement/ImageBackground/ImageBackgroundManager.Loaders.cs
@@ -131,11 +131,12 @@ public partial class ImageBackgroundManager
                 (!overlayRequired || localOverlay != null) &&
                 (!staticRequired  || localStatic != null))
             {
-                bool willDisplayStatic = !IsVideoMediaFileExtensionSupported(primaryBg ?? staticBgUrl!) ||
-                                         (!CurrentIsEnableCustomImage &&
-                                          !GlobalIsEnableCustomImage &&
-                                          !CurrentIsEnableBackgroundAutoPlay);
-                Uri accentPreviewUri = willDisplayStatic ? new Uri(localStatic) : new Uri(localBackground);
+                bool willDisplayStatic = (!IsVideoMediaFileExtensionSupported(primaryBg ?? staticBgUrl!) ||
+                                          (!CurrentIsEnableCustomImage &&
+                                           !GlobalIsEnableCustomImage &&
+                                           !CurrentIsEnableBackgroundAutoPlay))
+                                         && localStatic != null;
+                Uri accentPreviewUri = willDisplayStatic ? new Uri(localStatic!) : new Uri(localBackground);
 
                 RestoreSavedAccent(cachedBgKey, accentPreviewUri);
 

--- a/CollapseLauncher/Classes/GameManagement/ImageBackground/ImageBackgroundManager.StreamAndPath.cs
+++ b/CollapseLauncher/Classes/GameManagement/ImageBackground/ImageBackgroundManager.StreamAndPath.cs
@@ -207,4 +207,41 @@ public partial class ImageBackgroundManager
 
         return source[Random.Shared.Next(0, source.Length - 1)];
     }
+
+    internal static bool CheckIsContextCached(LayeredImageBackgroundContext ctx)
+    {
+        bool backgroundCached = false;
+        if (!string.IsNullOrEmpty(ctx.BackgroundImagePath) &&
+            TryGetDownloadedFile(new Uri(ctx.BackgroundImagePath), out _, out _, out _))
+        {
+            backgroundCached = true;
+        }
+        else if (!string.IsNullOrEmpty(ctx.BackgroundImageStaticPath) &&
+                 TryGetDownloadedFile(new Uri(ctx.BackgroundImageStaticPath), out _, out _, out _))
+        {
+            backgroundCached = true;
+        }
+
+        return backgroundCached;
+    }
+
+    internal static string? TryGetCachedLocalPath(string? urlOrPath)
+    {
+        if (string.IsNullOrEmpty(urlOrPath))
+        {
+            return null;
+        }
+
+        if (TryGetDecodedTemporaryFile(urlOrPath, out string decodedFilePath))
+        {
+            return decodedFilePath;
+        }
+
+        if (TryGetDownloadedFile(new Uri(urlOrPath), out FileInfo downloadedFile, out _, out _))
+        {
+            return downloadedFile.FullName;
+        }
+
+        return null;
+    }
 }

--- a/CollapseLauncher/Classes/GameManagement/ImageBackground/ImageBackgroundManager.cs
+++ b/CollapseLauncher/Classes/GameManagement/ImageBackground/ImageBackgroundManager.cs
@@ -191,12 +191,17 @@ public partial class ImageBackgroundManager
     #region This Instance Properties
 
     private string                    CurrentCustomBackgroundConfigKey     { get; set; } = "";
+    private string                    CurrentCachedBgKey                   { get; set; } = "";
     private string                    CurrentIsEnableCustomImageConfigKey  { get; set; } = "";
     private string                    CurrentSelectedBackgroundIndexKey    { get; set; } = "";
     private string                    CurrentIsEnableBackgroundAutoPlayKey { get; set; } = "";
     private HypLauncherBackgroundApi? CurrentBackgroundApi                 { get; set; }
     private Grid?                     PresenterGrid                        { get; set; }
     private PresetConfig?             PresetConfig                         { get; set; }
+
+    internal bool NeedFallbackPlaceholder { get; set; }
+
+    public Action? OnBackgroundLoadFailed { get; set; }
 
     public string? CurrentCustomBackgroundImagePath
     {
@@ -252,7 +257,7 @@ public partial class ImageBackgroundManager
 
             LauncherConfig.SetAndSaveConfigValue(CurrentSelectedBackgroundIndexKey, value);
             OnPropertyChanged();
-            LoadImageAtIndex(value, false, CancellationToken.None);
+            LoadImageAtIndex(value, false, CancellationToken.None, true);
         }
     }
 
@@ -316,6 +321,12 @@ public partial class ImageBackgroundManager
 
     private int _previousContextHash;
 
+    private volatile int _loadGeneration;
+
+    private LayeredImageBackgroundContext? _displayedContext;
+
+    internal FrameworkElement? ThemeRootElement { get; set; }
+
     #endregion
 
     /// <summary>
@@ -337,6 +348,7 @@ public partial class ImageBackgroundManager
         CurrentSelectedBackgroundIndexKey    = $"LastCustomBgIndex-{presetConfig.GameName}-{presetConfig.ZoneName}";
         CurrentIsEnableCustomImageConfigKey  = $"LastIsCustomImageEnabled-{presetConfig.GameName}-{presetConfig.ZoneName}";
         CurrentIsEnableBackgroundAutoPlayKey = $"LastIsEnableBackgroundAutoPlay-{presetConfig.GameName}-{presetConfig.ZoneName}";
+        CurrentCachedBgKey                   = $"CachedBg-{presetConfig.GameName}-{presetConfig.ZoneName}";
 
         PresetConfig         = presetConfig;
         CurrentBackgroundApi = backgroundApi;
@@ -534,6 +546,15 @@ public partial class ImageBackgroundManager
         bool                                               skipPreviousContextCheck,
         params ReadOnlySpan<LayeredImageBackgroundContext> imageContexts)
     {
+        UpdateContextListCore(token, skipPreviousContextCheck, false, imageContexts);
+    }
+
+    private void UpdateContextListCore(
+        CancellationToken                                  token,
+        bool                                               skipPreviousContextCheck,
+        bool                                               forceLoadToStatic,
+        params ReadOnlySpan<LayeredImageBackgroundContext> imageContexts)
+    {
         // Do not update if the previous contexts are equal
         if ((!skipPreviousContextCheck &&
             IsContextEqual(imageContexts)) ||
@@ -541,6 +562,8 @@ public partial class ImageBackgroundManager
         {
             return;
         }
+
+        Interlocked.Increment(ref _loadGeneration);
 
         ImageContextSources.Clear(); // Flush list
         ref IList<LayeredImageBackgroundContext>? backedList =
@@ -568,7 +591,7 @@ public partial class ImageBackgroundManager
         OnPropertyChanged(nameof(CurrentSelectedBackgroundIndex));
         OnPropertyChanged(nameof(CurrentSelectedBackgroundContext));
         OnPropertyChanged(nameof(CurrentBackgroundCount));
-        LoadImageAtIndex(CurrentSelectedBackgroundIndex, false, token);
+        LoadImageAtIndex(CurrentSelectedBackgroundIndex, forceLoadToStatic, token);
     }
 #pragma warning restore CA1068
 
@@ -593,6 +616,7 @@ public partial class ImageBackgroundManager
     {
         Interlocked.Exchange(ref _previousContextHash, 0);
         ImageContextSources.Clear();
+        NeedFallbackPlaceholder = false;
     }
 
     void INotifyAllPropertyChanged.NotifyAllChanged()

--- a/CollapseLauncher/Classes/RegionManagement/RegionManagement.cs
+++ b/CollapseLauncher/Classes/RegionManagement/RegionManagement.cs
@@ -11,6 +11,7 @@ using Hi3Helper;
 using Hi3Helper.Plugin.Core.Management;
 using Hi3Helper.SentryHelper;
 using Hi3Helper.Shared.ClassStruct;
+using Hi3Helper.Shared.Region;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using System;
@@ -167,6 +168,14 @@ namespace CollapseLauncher
                         LogWriteLine($"Initializing game: {regionToChangeName}...", LogType.Scheme, true);
                     
                         ClearMainPageState();
+
+                        bool isCustom = LauncherConfig.GetAppConfigValue($"LastIsCustomImageEnabled-{preset.GameName}-{preset.ZoneName}").ToBool();
+                        if (!isCustom)
+                        {
+                            DispatcherQueue.TryEnqueue(() =>
+                                ImageBackgroundManager.Shared.PreloadBackground(preset, BackgroundPresenterGrid));
+                        }
+
                         _ = ShowAsyncLoadingTimedOutPill(token);
                     }
                     catch (Exception ex)

--- a/CollapseLauncher/XAMLs/MainApp/MainPage.xaml
+++ b/CollapseLauncher/XAMLs/MainApp/MainPage.xaml
@@ -35,6 +35,9 @@
             <customControls:LayeredBackgroundImage x:Name="PlaceholderBackgroundLayer"
                                                    BackgroundSource="{x:Bind PlaceholderBackgroundImage}"
                                                    MediaSourceCacheDir="{x:Bind PlaceholderDecodedCacheDir}">
+                <customControls:LayeredBackgroundImage.OpacityTransition>
+                    <ScalarTransition Duration="0:0:0.2" />
+                </customControls:LayeredBackgroundImage.OpacityTransition>
                 <customControls:LayeredBackgroundImage.Transitions>
                     <PopupThemeTransition/>
                 </customControls:LayeredBackgroundImage.Transitions>

--- a/CollapseLauncher/XAMLs/MainApp/MainPage.xaml
+++ b/CollapseLauncher/XAMLs/MainApp/MainPage.xaml
@@ -33,7 +33,6 @@
         <Grid x:Name="BackgroundPresenterGrid"
               x:FieldModifier="internal">
             <customControls:LayeredBackgroundImage x:Name="PlaceholderBackgroundLayer"
-                                                   Visibility="Collapsed"
                                                    BackgroundSource="{x:Bind PlaceholderBackgroundImage}"
                                                    MediaSourceCacheDir="{x:Bind PlaceholderDecodedCacheDir}">
                 <customControls:LayeredBackgroundImage.Transitions>

--- a/CollapseLauncher/XAMLs/MainApp/MainPage.xaml
+++ b/CollapseLauncher/XAMLs/MainApp/MainPage.xaml
@@ -32,7 +32,9 @@
           Background="{ThemeResource WindowBackground}">
         <Grid x:Name="BackgroundPresenterGrid"
               x:FieldModifier="internal">
-            <customControls:LayeredBackgroundImage BackgroundSource="{x:Bind PlaceholderBackgroundImage}"
+            <customControls:LayeredBackgroundImage x:Name="PlaceholderBackgroundLayer"
+                                                   Visibility="Collapsed"
+                                                   BackgroundSource="{x:Bind PlaceholderBackgroundImage}"
                                                    MediaSourceCacheDir="{x:Bind PlaceholderDecodedCacheDir}">
                 <customControls:LayeredBackgroundImage.Transitions>
                     <PopupThemeTransition/>

--- a/CollapseLauncher/XAMLs/MainApp/MainPage.xaml.cs
+++ b/CollapseLauncher/XAMLs/MainApp/MainPage.xaml.cs
@@ -114,7 +114,12 @@ namespace CollapseLauncher
 
         private void SharedOnBackgroundLoadFailed()
         {
-            DispatcherQueue.TryEnqueue(() => PlaceholderBackgroundLayer.Visibility = Visibility.Visible);
+            DispatcherQueue.TryEnqueue(() =>
+            {
+                if (!BackgroundPresenterGrid.Children.Contains(PlaceholderBackgroundLayer))
+                    BackgroundPresenterGrid.Children.Insert(0, PlaceholderBackgroundLayer);
+                PlaceholderBackgroundLayer.Visibility = Visibility.Visible;
+            });
         }
 
         private void Page_Unloaded(object sender, RoutedEventArgs e)

--- a/CollapseLauncher/XAMLs/MainApp/MainPage.xaml.cs
+++ b/CollapseLauncher/XAMLs/MainApp/MainPage.xaml.cs
@@ -94,6 +94,8 @@ namespace CollapseLauncher
 
                 ImageBackgroundManager.Shared.GlobalParallaxHoverSource = MainPageGrid;
                 ImageBackgroundManager.Shared.ColorAccentChanged += SharedOnColorAccentChanged;
+                ImageBackgroundManager.Shared.OnBackgroundLoadFailed += SharedOnBackgroundLoadFailed;
+                ImageBackgroundManager.Shared.ThemeRootElement = this;
 
                 // Enable implicit animation on certain elements
                 AnimationHelper.EnableImplicitAnimation(true, null, GridBGRegionGrid, GridBGNotifBtn, NotificationPanelClearAllGrid);
@@ -108,8 +110,11 @@ namespace CollapseLauncher
         private void SharedOnColorAccentChanged(Color color)
         {
             DispatcherQueue.TryEnqueue(() => this.ChangeAccentColor(color));
-            DispatcherQueue.TryEnqueue(() => this.ChangeAccentColor(color));
-            DispatcherQueue.TryEnqueue(() => this.ChangeAccentColor(color));
+        }
+
+        private void SharedOnBackgroundLoadFailed()
+        {
+            DispatcherQueue.TryEnqueue(() => PlaceholderBackgroundLayer.Visibility = Visibility.Visible);
         }
 
         private void Page_Unloaded(object sender, RoutedEventArgs e)
@@ -419,6 +424,7 @@ namespace CollapseLauncher
             KeyboardShortcuts.KeyboardShortcutsEvent -= SettingsPage_KeyboardShortcutsEvent;
             GridBGRegionGrid.SizeChanged             -= GridBG_RegionGrid_SizeChanged;
             MainPageGrid.SizeChanged                 -= MainPageGrid_SizeChanged;
+            ImageBackgroundManager.Shared.OnBackgroundLoadFailed -= SharedOnBackgroundLoadFailed;
         }
         #endregion
 

--- a/CollapseLauncher/XAMLs/MainApp/MainPage.xaml.cs
+++ b/CollapseLauncher/XAMLs/MainApp/MainPage.xaml.cs
@@ -118,7 +118,7 @@ namespace CollapseLauncher
             {
                 if (!BackgroundPresenterGrid.Children.Contains(PlaceholderBackgroundLayer))
                     BackgroundPresenterGrid.Children.Insert(0, PlaceholderBackgroundLayer);
-                PlaceholderBackgroundLayer.Visibility = Visibility.Visible;
+                PlaceholderBackgroundLayer.Opacity = 1;
             });
         }
 

--- a/CollapseLauncher/XAMLs/Theme/CustomControls/LayeredBackgroundImage.Events.Loaders.cs
+++ b/CollapseLauncher/XAMLs/Theme/CustomControls/LayeredBackgroundImage.Events.Loaders.cs
@@ -108,13 +108,17 @@ public partial class LayeredBackgroundImage
         }
 
         Grid grid = element._placeholderGrid;
-        element.LoadFromSourceAsyncDetached(PlaceholderSourceProperty,
-                                            nameof(PlaceholderStretch),
-                                            nameof(PlaceholderHorizontalAlignment),
-                                            nameof(PlaceholderVerticalAlignment),
-                                            grid,
-                                            false,
-                                            ref element._lastPlaceholderSourceType);
+        if (!IsSourceKindEquals(element._lastPlaceholderSource, element.PlaceholderSource))
+        {
+            element.LoadFromSourceAsyncDetached(PlaceholderSourceProperty,
+                                                nameof(PlaceholderStretch),
+                                                nameof(PlaceholderHorizontalAlignment),
+                                                nameof(PlaceholderVerticalAlignment),
+                                                grid,
+                                                false,
+                                                ref element._lastPlaceholderSourceType);
+            element._lastPlaceholderSource = element.PlaceholderSource;
+        }
     }
 
     private static void BackgroundSource_OnChange(DependencyObject d, DependencyPropertyChangedEventArgs e)
@@ -129,11 +133,19 @@ public partial class LayeredBackgroundImage
         // then load static background source.
         if (element is { CanUseStaticBackground: true, IsVideoPlay: true } or { CanUseStaticBackground: true, IsUseStaticBackgroundUsed: true })
         {
-            BackgroundSource_UseStatic(element);
+            if (!IsSourceKindEquals(element._lastBackgroundStaticSource, element.BackgroundStaticSource))
+            {
+                BackgroundSource_UseStatic(element);
+                element._lastBackgroundStaticSource = element.BackgroundStaticSource;
+            }
             return;
         }
 
-        BackgroundSource_UseNormal(element);
+        if (!IsSourceKindEquals(element._lastBackgroundSource, element.BackgroundSource))
+        {
+            BackgroundSource_UseNormal(element);
+            element._lastBackgroundSource = element.BackgroundSource;
+        }
     }
 
     private static void BackgroundSource_UseStatic(LayeredBackgroundImage element)
@@ -174,13 +186,17 @@ public partial class LayeredBackgroundImage
         }
 
         Grid grid = element._foregroundGrid;
-        element.LoadFromSourceAsyncDetached(ForegroundSourceProperty,
-                                            nameof(ForegroundStretch),
-                                            nameof(ForegroundHorizontalAlignment),
-                                            nameof(ForegroundVerticalAlignment),
-                                            grid,
-                                            false,
-                                            ref element._lastForegroundSourceType);
+        if (!IsSourceKindEquals(element._lastForegroundSource, element.ForegroundSource))
+        {
+            element.LoadFromSourceAsyncDetached(ForegroundSourceProperty,
+                                                nameof(ForegroundStretch),
+                                                nameof(ForegroundHorizontalAlignment),
+                                                nameof(ForegroundVerticalAlignment),
+                                                grid,
+                                                false,
+                                                ref element._lastForegroundSourceType);
+            element._lastForegroundSource = element.ForegroundSource;
+        }
     }
 
     private void LoadFromSourceAsyncDetached(
@@ -299,6 +315,7 @@ public partial class LayeredBackgroundImage
             image.BindProperty(instance, horizontalAlignmentProperty, HorizontalAlignmentProperty, BindingMode.OneWay);
             image.BindProperty(instance, verticalAlignmentProperty,   VerticalAlignmentProperty,   BindingMode.OneWay);
 
+            ClearMediaGrid(grid);
             grid.Children.Add(image);
 
             image.Tag         =  (grid, instance);


### PR DESCRIPTION
# Main Goal
Cache background image URLs to config and preload background before region loading, so the cached or preset background appears instantly on game switch without waiting for API download.
If the background files are cached locally, the background is displayed immediately. If not cached, the game-specific preset placeholder is shown while the real background downloads in the background.

Games added via plugins have not yet been tested.

## PR Status :
- Overall Status : WIP
- Commits : WIP
- Synced to base (Collapse:main) : Yes
- Build status : OK
- Crashing : No
- Bug found caused by PR : -
